### PR TITLE
Remove erroneous LOG message.

### DIFF
--- a/config/workload_all.xml
+++ b/config/workload_all.xml
@@ -33,7 +33,7 @@
     <useThinkTime>true</useThinkTime>
     <works>
         <work>
-          <time>30</time>
+          <time>300</time>
           <rate>10000</rate>
           <ratelimited bench="tpcc">true</ratelimited>
           <weights>45,43,4,4,4</weights>

--- a/src/com/oltpbenchmark/benchmarks/tpcc/TPCCWorker.java
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/TPCCWorker.java
@@ -61,7 +61,6 @@ public class TPCCWorker extends Worker<TPCCBenchmark> {
 		assert terminalDistrictLowerID <= terminalDistrictUpperID;
         this.terminalDistrictID = TPCCUtil.randomNumber(terminalDistrictLowerID,terminalDistrictUpperID, gen);
 		this.numWarehouses = numWarehouses;
-        LOG.error("Warehouse and house district " + terminalWarehouseID + " " + terminalDistrictID);
 	}
 
 	/**


### PR DESCRIPTION
Removed the erroneous LOG message.
Changed the running time from 30 seconds to 300 seconds by default.