### PR TITLE
Using one tag per DBUrl for easier understanding of tpcc configuration.

### DIFF
--- a/config/workload_all.xml
+++ b/config/workload_all.xml
@@ -2,7 +2,11 @@
 <parameters>
     <dbtype>postgres</dbtype>
     <driver>org.postgresql.Driver</driver>
-    <DBUrl>jdbc:postgresql://127.0.0.1:5433/yugabyte</DBUrl>
+    <DBUrls>
+      <DBUrl>jdbc:postgresql://127.0.0.1:5433/yugabyte</DBUrl>
+      <DBUrl>jdbc:postgresql://127.0.0.2:5433/yugabyte</DBUrl>
+      <DBUrl>jdbc:postgresql://127.0.0.3:5433/yugabyte</DBUrl>
+    </DBUrls>
     <username>yugabyte</username>
     <password></password>
     <isolation>TRANSACTION_REPEATABLE_READ</isolation>

--- a/config/workload_all.xml
+++ b/config/workload_all.xml
@@ -3,9 +3,8 @@
     <dbtype>postgres</dbtype>
     <driver>org.postgresql.Driver</driver>
     <DBUrls>
+      <!-- Add as many DBUrl as the number of nodes present.  -->
       <DBUrl>jdbc:postgresql://127.0.0.1:5433/yugabyte</DBUrl>
-      <DBUrl>jdbc:postgresql://127.0.0.2:5433/yugabyte</DBUrl>
-      <DBUrl>jdbc:postgresql://127.0.0.3:5433/yugabyte</DBUrl>
     </DBUrls>
     <username>yugabyte</username>
     <password></password>

--- a/src/com/oltpbenchmark/DBWorkload.java
+++ b/src/com/oltpbenchmark/DBWorkload.java
@@ -201,7 +201,11 @@ public class DBWorkload {
             // Pull in database configuration
             wrkld.setDBType(DatabaseType.get(xmlConfig.getString("dbtype")));
             wrkld.setDBDriver(xmlConfig.getString("driver"));
-            wrkld.setDBConnection(xmlConfig.getString("DBUrl"));
+
+            Object obj = xmlConfig.getProperty("DBUrls/DBUrl");
+            List<String> dbConnections = (List<String>)obj;
+            wrkld.setDBConnections(dbConnections);
+
             wrkld.setDBName(xmlConfig.getString("DBName"));
             wrkld.setDBUsername(xmlConfig.getString("username"));
             wrkld.setDBPassword(xmlConfig.getString("password"));
@@ -267,7 +271,7 @@ public class DBWorkload {
             initDebug.put("Configuration", configFile);
             initDebug.put("Type", wrkld.getDBType());
             initDebug.put("Driver", wrkld.getDBDriver());
-            initDebug.put("URL", wrkld.getDBConnection());
+            initDebug.put("URL", wrkld.getDBConnections());
             initDebug.put("Isolation", wrkld.getIsolationString());
             initDebug.put("Scale Factor", wrkld.getScaleFactor());
 

--- a/src/com/oltpbenchmark/WorkloadConfiguration.java
+++ b/src/com/oltpbenchmark/WorkloadConfiguration.java
@@ -43,7 +43,7 @@ public class WorkloadConfiguration {
         this.benchmarkName = benchmarkName;
     }
 
-    private String db_connection;
+    private List<String> dbConnections;
 	private String db_name;
 	private String db_username;
 	private String db_password;
@@ -103,12 +103,12 @@ public class WorkloadConfiguration {
         return db_type;
     }
 
-	public void setDBConnection(String database) {
-		this.db_connection = database;
+	public void setDBConnections(List<String> connections) {
+      this.dbConnections = connections;
 	}
 
-	public String getDBConnection() {
-		return db_connection;
+	public List<String> getDBConnections() {
+		return dbConnections;
 	}
 
 	public void setDBName(String dbname) {

--- a/src/com/oltpbenchmark/api/BenchmarkModule.java
+++ b/src/com/oltpbenchmark/api/BenchmarkModule.java
@@ -24,12 +24,7 @@ import java.net.URL;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.log4j.Logger;
 
@@ -117,10 +112,9 @@ public abstract class BenchmarkModule {
         props.put("password", workConf.getDBPassword());
         props.put("reWriteBatchedInserts", "true");
 
-        String[] dbConnections = workConf.getDBConnection().split(",");
-        int r = (int)TPCCUtil.randomNumber(0, dbConnections.length - 1, rng);
-
-        Connection conn = DriverManager.getConnection(dbConnections[r], props);
+        List<String> dbConnections = workConf.getDBConnections();
+        int r = (int)TPCCUtil.randomNumber(0, dbConnections.size() - 1, rng);
+        Connection conn = DriverManager.getConnection(dbConnections.get(r), props);
         Catalog.setSeparator(conn);
         return (conn);
     }

--- a/src/com/oltpbenchmark/api/collectors/DBCollector.java
+++ b/src/com/oltpbenchmark/api/collectors/DBCollector.java
@@ -104,7 +104,7 @@ public abstract class DBCollector {
     public static DBCollector createCollector(WorkloadConfiguration workConf) {
         return createCollector(
                 workConf.getDBType(),
-                workConf.getDBConnection(),
+                workConf.getDBConnections().get(0),
                 workConf.getDBUsername(),
                 workConf.getDBPassword());
     }


### PR DESCRIPTION
Reviewers:
MIkhail, Neha, Karthik

Test Plan:
Added a LOG line indicating the DB connection used:

```12:51:11,809 (DBWorkload.java:286) INFO  - ======================================================================
12:51:11,827 (DBWorkload.java:548) INFO  - Creating new TPCC database...
12:51:11,827 (BenchmarkModule.java:117) INFO  - db connection jdbc:postgresql://127.0.0.1:5433/yugabyte
12:51:11,828 (BenchmarkModule.java:117) INFO  - db connection jdbc:postgresql://127.0.0.2:5433/yugabyte
12:51:11,829 (BenchmarkModule.java:117) INFO  - db connection jdbc:postgresql://127.0.0.3:5433/yugabyte
12:51:25,845 (DBWorkload.java:550) INFO  - Finished!
12:51:25,845 (DBWorkload.java:551) INFO  - ======================================================================
12:51:25,846 (DBWorkload.java:574) INFO  - Loading data into TPCC database with 10 threads...
12:51:25,850 (BenchmarkModule.java:117) INFO  - db connection jdbc:postgresql://127.0.0.1:5433/yugabyte
12:51:25,850 (BenchmarkModule.java:117) INFO  - db connection jdbc:postgresql://127.0.0.2:5433/yugabyte
12:51:25,850 (BenchmarkModule.java:117) INFO  - db connection jdbc:postgresql://127.0.0.3:5433/yugabyte
12:51:31,827 (BenchmarkModule.java:117) INFO  - db connection jdbc:postgresql://127.0.0.1:5433/yugabyte
12:51:31,827 (BenchmarkModule.java:117) INFO  - db connection jdbc:postgresql://127.0.0.2:5433/yugabyte
12:51:31,827 (BenchmarkModule.java:117) INFO  - db connection jdbc:postgresql://127.0.0.3:5433/yugabyte
12:51:37,752 (BenchmarkModule.java:117) INFO  - db connection jdbc:postgresql://127.0.0.1:5433/yugabyte
12:51:37,752 (BenchmarkModule.java:117) INFO  - db connection jdbc:postgresql://127.0.0.2:5433/yugabyte
```