### PR TITLE
DBUrls fix for 1 URL.

### DIFF
--- a/src/com/oltpbenchmark/DBWorkload.java
+++ b/src/com/oltpbenchmark/DBWorkload.java
@@ -206,7 +206,12 @@ public class DBWorkload {
             wrkld.setDBDriver(xmlConfig.getString("driver"));
 
             Object obj = xmlConfig.getProperty("DBUrls/DBUrl");
-            List<String> dbConnections = (List<String>)obj;
+            List<String> dbConnections = new LinkedList<>();
+            if (obj instanceof List<?>) {
+                dbConnections = (List<String>)obj;
+            } else {
+                dbConnections.add((String)obj);
+            }
             wrkld.setDBConnections(dbConnections);
 
             wrkld.setDBName(xmlConfig.getString("DBName"));


### PR DESCRIPTION
Summary:
When there is one DBUrl the xml getProperty method returns a single
String instead of a List of Strings. The code uses reflection to
distinguish the 2 cases and creates a list.

Reviewers:
Neha, Mikhail