### PR TITLE
Adding support for connection pooling in TPCC.

### DIFF
--- a/config/workload_all.xml
+++ b/config/workload_all.xml
@@ -2,11 +2,13 @@
 <parameters>
     <dbtype>postgres</dbtype>
     <driver>org.postgresql.Driver</driver>
-    <DBUrls>
+    <nodes>
       <!-- Add as many DBUrl as the number of nodes present.  -->
-      <DBUrl>jdbc:postgresql://127.0.0.1:5433/yugabyte</DBUrl>
-    </DBUrls>
+      <node>127.0.0.1</node>
+    </nodes>
+    <port>5433</port>
     <username>yugabyte</username>
+    <DBName>yugabyte</DBName>
     <password></password>
     <isolation>TRANSACTION_REPEATABLE_READ</isolation>
 
@@ -17,6 +19,9 @@
     <!-- TPC-C 4.2.2: The number of terminals should be 10 per warehouse -->
     <terminals>100</terminals>
     <batchSize>128</batchSize>
+
+      <!-- The actual number of connections used  -->
+    <numDBConnections>10</numDBConnections>
 
     <useKeyingTime>true</useKeyingTime>
     <useThinkTime>true</useThinkTime>

--- a/config/workload_all.xml
+++ b/config/workload_all.xml
@@ -3,10 +3,9 @@
     <dbtype>postgres</dbtype>
     <driver>org.postgresql.Driver</driver>
     <nodes>
-      <!-- Add as many DBUrl as the number of nodes present.  -->
+      <!-- Add as many node entries as the number of nodes present.  -->
       <node>127.0.0.1</node>
     </nodes>
-    <port>5433</port>
     <username>yugabyte</username>
     <DBName>yugabyte</DBName>
     <password></password>

--- a/ivy.xml
+++ b/ivy.xml
@@ -23,7 +23,9 @@
 		<dependency org="com.yugabyte" name="jdbc-yugabytedb" rev="42.2.7-yb-3" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="org.hsqldb" name="hsqldb" rev="2.4.1" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 
-      <!-- Core Libraries -->
+		<dependency org="com.zaxxer" name="HikariCP" rev="3.4.5" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
+
+		<!-- Core Libraries -->
 		<dependency org="org.apache.httpcomponents" name="httpclient" rev="4.3" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="org.apache.httpcomponents" name="httpcore" rev="4.3" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>
 		<dependency org="org.apache.httpcomponents" name="httpmime" rev="4.3" force="true" conf="compile->compile(*),master(*);runtime->runtime(*)"/>

--- a/src/com/oltpbenchmark/DBWorkload.java
+++ b/src/com/oltpbenchmark/DBWorkload.java
@@ -234,46 +234,28 @@ public class DBWorkload {
             wrkld.setRecordAbortMessages(xmlConfig.getBoolean("recordabortmessages", false));
             wrkld.setDataDir(xmlConfig.getString("datadir", "."));
 
-            double selectivity = -1;
-            try {
-                selectivity = xmlConfig.getDouble("selectivity");
-                wrkld.setSelectivity(selectivity);
+            if (xmlConfig.containsKey("useKeyingTime")) {
+                wrkld.setUseKeyingTime(xmlConfig.getBoolean("useKeyingTime"));
             }
-            catch(NoSuchElementException nse) {
-                // Nothing to do here !
+            if (xmlConfig.containsKey("useThinkTime")) {
+                wrkld.setUseKeyingTime(xmlConfig.getBoolean("useThinkTime"));
             }
 
-            try {
-              // Whether to enable the queuing and keying times based on the TPC-C standard.
-              wrkld.setUseKeyingTime(xmlConfig.getBoolean("useKeyingTime"));
-              wrkld.setUseThinkTime(xmlConfig.getBoolean("useThinkTime"));
-            } catch(NoSuchElementException nse) {
-                // Nothing to do here !
+            if (xmlConfig.containsKey("enableForeignKeysAfterLoad")) {
+                wrkld.setEnableForeignKeysAfterLoad(xmlConfig.getBoolean("enableForeignKeysAfterLoad"));
             }
 
-            try {
-              // Whether to defer the foreign key checks until after the loading of the data is done.
-              wrkld.setEnableForeignKeysAfterLoad(xmlConfig.getBoolean("enableForeignKeysAfterLoad"));
-            } catch(NoSuchElementException nse) {
-                // Nothing to do here !
+            if (xmlConfig.containsKey("batchSize")) {
+                wrkld.setBatchSize(xmlConfig.getInt("batchSize"));
             }
 
-            try {
-              wrkld.setBatchSize(xmlConfig.getInt("batchSize"));
-            } catch(NoSuchElementException nse) {
-                // Nothing to do here !
-            }
-
-            try {
+            if (xmlConfig.containsKey("port")) {
+                LOG.info("port exists");
                 wrkld.setPort(xmlConfig.getInt("port"));
-            } catch(NoSuchElementException nse) {
-                // Nothing to do here !
             }
 
-            try {
+            if (xmlConfig.containsKey("numDBConnections")) {
                 wrkld.setNumDBConnections(xmlConfig.getInt("numDBConnections"));
-            } catch(NoSuchElementException nse) {
-                // Nothing to do here !
             }
 
             if (wrkld.getNumDBConnections() <= 0) {
@@ -303,9 +285,6 @@ public class DBWorkload {
             initDebug.put("URL", wrkld.getNodes());
             initDebug.put("Isolation", wrkld.getIsolationString());
             initDebug.put("Scale Factor", wrkld.getScaleFactor());
-
-            if(selectivity != -1)
-                initDebug.put("Selectivity", selectivity);
 
             LOG.info(SINGLE_LINE + "\n\n" + StringUtil.formatMaps(initDebug));
             LOG.info(SINGLE_LINE);

--- a/src/com/oltpbenchmark/DBWorkload.java
+++ b/src/com/oltpbenchmark/DBWorkload.java
@@ -205,14 +205,14 @@ public class DBWorkload {
             wrkld.setDBType(DatabaseType.get(xmlConfig.getString("dbtype")));
             wrkld.setDBDriver(xmlConfig.getString("driver"));
 
-            Object obj = xmlConfig.getProperty("DBUrls/DBUrl");
-            List<String> dbConnections = new LinkedList<>();
+            Object obj = xmlConfig.getProperty("nodes/node");
+            List<String> nodes = new LinkedList<>();
             if (obj instanceof List<?>) {
-                dbConnections = (List<String>)obj;
+                nodes = (List<String>)obj;
             } else {
-                dbConnections.add((String)obj);
+                nodes.add((String)obj);
             }
-            wrkld.setDBConnections(dbConnections);
+            wrkld.setNodes(nodes);
 
             wrkld.setDBName(xmlConfig.getString("DBName"));
             wrkld.setDBUsername(xmlConfig.getString("username"));
@@ -264,6 +264,26 @@ public class DBWorkload {
                 // Nothing to do here !
             }
 
+            try {
+                wrkld.setPort(xmlConfig.getInt("port"));
+            } catch(NoSuchElementException nse) {
+                // Nothing to do here !
+            }
+
+            try {
+                wrkld.setNumDBConnections(xmlConfig.getInt("numDBConnections"));
+            } catch(NoSuchElementException nse) {
+                // Nothing to do here !
+            }
+
+            if (wrkld.getNumDBConnections() <= 0) {
+                wrkld.setNumDBConnections(wrkld.getTerminals());
+            }
+
+            if (wrkld.getNumDBConnections() < wrkld.getLoaderThreads()) {
+                wrkld.setNumDBConnections(wrkld.getLoaderThreads());
+            }
+
             // ----------------------------------------------------------------
             // CREATE BENCHMARK MODULE
             // ----------------------------------------------------------------
@@ -280,7 +300,7 @@ public class DBWorkload {
             initDebug.put("Configuration", configFile);
             initDebug.put("Type", wrkld.getDBType());
             initDebug.put("Driver", wrkld.getDBDriver());
-            initDebug.put("URL", wrkld.getDBConnections());
+            initDebug.put("URL", wrkld.getNodes());
             initDebug.put("Isolation", wrkld.getIsolationString());
             initDebug.put("Scale Factor", wrkld.getScaleFactor());
 

--- a/src/com/oltpbenchmark/WorkloadConfiguration.java
+++ b/src/com/oltpbenchmark/WorkloadConfiguration.java
@@ -43,7 +43,7 @@ public class WorkloadConfiguration {
         this.benchmarkName = benchmarkName;
     }
 
-    private List<String> dbConnections;
+    private List<String> nodes;
 	private String db_name;
 	private String db_username;
 	private String db_password;
@@ -51,6 +51,8 @@ public class WorkloadConfiguration {
 	private double scaleFactor = 1.0;
 	private double selectivity = -1.0;
 	private int terminals;
+	private int numDBConnections = -1;
+	private int port = 5433;
 	private int loaderThreads = ThreadUtil.availableProcessors();
 	private int numTxnTypes;
     private TraceReader traceReader = null;
@@ -103,12 +105,12 @@ public class WorkloadConfiguration {
         return db_type;
     }
 
-	public void setDBConnections(List<String> connections) {
-      this.dbConnections = connections;
+	public void setNodes(List<String> nodes) {
+      this.nodes = nodes;
 	}
 
-	public List<String> getDBConnections() {
-		return dbConnections;
+	public List<String> getNodes() {
+		return nodes;
 	}
 
 	public void setDBName(String dbname) {
@@ -243,6 +245,14 @@ public class WorkloadConfiguration {
 	public int getTerminals() {
 		return terminals;
 	}
+
+	public void setNumDBConnections(int numDBConnections) { this.numDBConnections = numDBConnections; }
+
+	public int getNumDBConnections() { return this.numDBConnections; }
+
+	public void setPort(int port) { this.port = port; }
+
+	public int getPort() { return port; }
 
 	public TransactionTypes getTransTypes() {
 		return transTypes;

--- a/src/com/oltpbenchmark/WorkloadConfiguration.java
+++ b/src/com/oltpbenchmark/WorkloadConfiguration.java
@@ -105,13 +105,9 @@ public class WorkloadConfiguration {
         return db_type;
     }
 
-	public void setNodes(List<String> nodes) {
-      this.nodes = nodes;
-	}
+	public void setNodes(List<String> nodes) { this.nodes = nodes; }
 
-	public List<String> getNodes() {
-		return nodes;
-	}
+	public List<String> getNodes() { return nodes; }
 
 	public void setDBName(String dbname) {
 		this.db_name = dbname;

--- a/src/com/oltpbenchmark/WorkloadConfiguration.java
+++ b/src/com/oltpbenchmark/WorkloadConfiguration.java
@@ -17,334 +17,352 @@
 
 package com.oltpbenchmark;
 
+import com.oltpbenchmark.api.TransactionTypes;
+import com.oltpbenchmark.types.DatabaseType;
+import com.oltpbenchmark.util.StringUtil;
+import com.oltpbenchmark.util.ThreadUtil;
+import org.apache.commons.collections15.map.ListOrderedMap;
+import org.apache.commons.configuration.XMLConfiguration;
+
 import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.collections15.map.ListOrderedMap;
-import org.apache.commons.configuration.XMLConfiguration;
-
-import com.oltpbenchmark.api.TransactionTypes;
-import com.oltpbenchmark.types.DatabaseType;
-import com.oltpbenchmark.util.StringUtil;
-import com.oltpbenchmark.util.ThreadUtil;
-
 public class WorkloadConfiguration {
 
-	private DatabaseType db_type;
-	private String benchmarkName;
-	public String getBenchmarkName() {
-        return benchmarkName;
+  private DatabaseType db_type;
+  private String benchmarkName;
+
+  public String getBenchmarkName() {
+    return benchmarkName;
+  }
+
+  public void setBenchmarkName(String benchmarkName) {
+    this.benchmarkName = benchmarkName;
+  }
+
+  private List<String> nodes;
+  private String db_name;
+  private String db_username;
+  private String db_password;
+  private String db_driver;
+  private double scaleFactor = 1.0;
+  private double selectivity = -1.0;
+  private int terminals;
+  private int numDBConnections = -1;
+  private int port = 5433;
+  private int loaderThreads = ThreadUtil.availableProcessors();
+  private int numTxnTypes;
+  private TraceReader traceReader = null;
+  private boolean useKeyingTime = true;
+  private boolean useThinkTime = true;
+  private boolean enableForeignKeysAfterLoad = true;
+  private int batchSize = 128;
+
+  public TraceReader getTraceReader() {
+    return traceReader;
+  }
+
+  public void setTraceReader(TraceReader traceReader) {
+    this.traceReader = traceReader;
+  }
+
+  private XMLConfiguration xmlConfig = null;
+
+  private final List<Phase> works = new ArrayList<Phase>();
+  private WorkloadState workloadState;
+
+  public WorkloadState getWorkloadState() {
+    return workloadState;
+  }
+
+  /**
+   * Initiate a new benchmark and workload state
+   */
+  public WorkloadState initializeState(BenchmarkState benchmarkState) {
+    assert (workloadState == null);
+    workloadState = new WorkloadState(benchmarkState, works, terminals, traceReader);
+    return workloadState;
+  }
+
+  private int numberOfPhases = 0;
+  private TransactionTypes transTypes = null;
+  private int isolationMode = Connection.TRANSACTION_SERIALIZABLE;
+  private boolean recordAbortMessages = false;
+  private String dataDir = null;
+
+  public void addWork(int time, int warmup, int rate, List<String> weights, boolean rateLimited, boolean disabled, boolean serial, boolean timed, int active_terminals, Phase.Arrival arrival) {
+    works.add(new Phase(benchmarkName, numberOfPhases, time, warmup, rate, weights, rateLimited, disabled, serial, timed, active_terminals, arrival));
+    numberOfPhases++;
+  }
+
+  public void setDBType(DatabaseType dbType) {
+    db_type = dbType;
+  }
+
+  public DatabaseType getDBType() {
+    return db_type;
+  }
+
+  public void setNodes(List<String> nodes) {
+    this.nodes = nodes;
+  }
+
+  public List<String> getNodes() {
+    return nodes;
+  }
+
+  public void setDBName(String dbname) {
+    this.db_name = dbname;
+  }
+
+  public void setLoaderThreads(int loaderThreads) {
+    this.loaderThreads = loaderThreads;
+  }
+
+  /**
+   * The number of loader threads that the framework is allowed to use.
+   *
+   * @return
+   */
+  public int getLoaderThreads() {
+    return this.loaderThreads;
+  }
+
+  public int getNumTxnTypes() {
+    return numTxnTypes;
+  }
+
+  public void setNumTxnTypes(int numTxnTypes) {
+    this.numTxnTypes = numTxnTypes;
+  }
+
+  public String getDBName() {
+    return db_name;
+  }
+
+  public void setDBUsername(String username) {
+    this.db_username = username;
+  }
+
+  public String getDBUsername() {
+    return db_username;
+  }
+
+  public void setDBPassword(String password) {
+    this.db_password = password;
+  }
+
+  public String getDBPassword() {
+    return this.db_password;
+  }
+
+  public void setSelectivity(double selectivity) {
+    this.selectivity = selectivity;
+  }
+
+  public double getSelectivity() {
+    return this.selectivity;
+  }
+
+  public void setDBDriver(String driver) {
+    this.db_driver = driver;
+  }
+
+  public String getDBDriver() {
+    return this.db_driver;
+  }
+
+  public void setRecordAbortMessages(boolean recordAbortMessages) {
+    this.recordAbortMessages = recordAbortMessages;
+  }
+
+  /**
+   * Whether each worker should record the transaction's UserAbort messages
+   * This primarily useful for debugging a benchmark
+   */
+  public boolean getRecordAbortMessages() {
+    return (this.recordAbortMessages);
+  }
+
+  /**
+   * Set the scale factor for the database
+   * A value of 1 means the default size.
+   * A value greater than 1 means the database is larger
+   * A value less than 1 means the database is smaller
+   *
+   * @param scaleFactor
+   */
+  public void setScaleFactor(double scaleFactor) {
+    this.scaleFactor = scaleFactor;
+  }
+
+  /**
+   * Return the scale factor of the database size
+   *
+   * @return
+   */
+  public double getScaleFactor() {
+    return this.scaleFactor;
+  }
+
+  /**
+   * Return the number of phases specified in the config file
+   *
+   * @return
+   */
+  public int getNumberOfPhases() {
+    return this.numberOfPhases;
+  }
+
+  /**
+   * Set the directory in which we can find the data files (for example, CSV
+   * files) for loading the database.
+   */
+  public void setDataDir(String dir) {
+    this.dataDir = dir;
+  }
+
+  /**
+   * Return the directory in which we can find the data files (for example, CSV
+   * files) for loading the database.
+   */
+  public String getDataDir() {
+    return this.dataDir;
+  }
+
+  /**
+   * A utility method that init the phaseIterator and dialectMap
+   */
+  public void init() {
+    try {
+      Class.forName(this.db_driver);
+    } catch (ClassNotFoundException ex) {
+      throw new RuntimeException("Failed to initialize JDBC driver '" + this.db_driver + "'", ex);
     }
+  }
 
-    public void setBenchmarkName(String benchmarkName) {
-        this.benchmarkName = benchmarkName;
-    }
+  public void setTerminals(int terminals) {
+    this.terminals = terminals;
+  }
 
-    private List<String> nodes;
-	private String db_name;
-	private String db_username;
-	private String db_password;
-	private String db_driver;
-	private double scaleFactor = 1.0;
-	private double selectivity = -1.0;
-	private int terminals;
-	private int numDBConnections = -1;
-	private int port = 5433;
-	private int loaderThreads = ThreadUtil.availableProcessors();
-	private int numTxnTypes;
-    private TraceReader traceReader = null;
-    private boolean useKeyingTime = true;
-    private boolean useThinkTime = true;
-    private boolean enableForeignKeysAfterLoad = true;
-    private int batchSize = 128;
+  public int getTerminals() {
+    return terminals;
+  }
 
-    public TraceReader getTraceReader() {
-        return traceReader;
-    }
-    public void setTraceReader(TraceReader traceReader) {
-        this.traceReader = traceReader;
-    }
+  public void setNumDBConnections(int numDBConnections) {
+    this.numDBConnections = numDBConnections;
+  }
 
-	private XMLConfiguration xmlConfig = null;
+  public int getNumDBConnections() {
+    return this.numDBConnections;
+  }
 
-	private List<Phase> works = new ArrayList<Phase>();
-	private WorkloadState workloadState;
+  public void setPort(int port) {
+    this.port = port;
+  }
 
-	public WorkloadState getWorkloadState() {
-        return workloadState;
-    }
+  public int getPort() {
+    return port;
+  }
 
-	/**
-	 * Initiate a new benchmark and workload state
-	 */
-    public WorkloadState initializeState(BenchmarkState benchmarkState) {
-        assert (workloadState == null);
-        workloadState = new WorkloadState(benchmarkState, works, terminals, traceReader);
-        return workloadState;
-    }
+  public TransactionTypes getTransTypes() {
+    return transTypes;
+  }
 
-    private int numberOfPhases = 0;
-	private TransactionTypes transTypes = null;
-	private int isolationMode = Connection.TRANSACTION_SERIALIZABLE;
-	private boolean recordAbortMessages = false;
-    private String dataDir = null;
+  public void setTransTypes(TransactionTypes transTypes) {
+    this.transTypes = transTypes;
+  }
 
-    public void addWork(int time, int warmup, int rate, List<String> weights, boolean rateLimited, boolean disabled, boolean serial, boolean timed, int active_terminals, Phase.Arrival arrival) {
-        works.add(new Phase(benchmarkName, numberOfPhases, time, warmup, rate, weights, rateLimited, disabled, serial, timed, active_terminals, arrival));
-		numberOfPhases++;
-	}
+  public List<Phase> getAllPhases() {
+    return works;
+  }
 
-	public void setDBType(DatabaseType dbType) {
-        db_type = dbType;
-    }
+  public void setXmlConfig(XMLConfiguration xmlConfig) {
+    this.xmlConfig = xmlConfig;
+  }
 
-	public DatabaseType getDBType() {
-        return db_type;
-    }
+  public XMLConfiguration getXmlConfig() {
+    return xmlConfig;
+  }
 
-	public void setNodes(List<String> nodes) { this.nodes = nodes; }
+  public int getIsolationMode() {
+    return isolationMode;
+  }
 
-	public List<String> getNodes() { return nodes; }
+  public String getIsolationString() {
+    if (this.isolationMode == Connection.TRANSACTION_SERIALIZABLE)
+      return "TRANSACTION_SERIALIZABLE";
+    else if (this.isolationMode == Connection.TRANSACTION_READ_COMMITTED)
+      return "TRANSACTION_READ_COMMITTED";
+    else if (this.isolationMode == Connection.TRANSACTION_REPEATABLE_READ)
+      return "TRANSACTION_REPEATABLE_READ";
+    else if (this.isolationMode == Connection.TRANSACTION_READ_UNCOMMITTED)
+      return "TRANSACTION_READ_UNCOMMITTED";
+    else
+      return "TRANSACTION_SERIALIZABLE [DEFAULT]";
+  }
 
-	public void setDBName(String dbname) {
-		this.db_name = dbname;
-	}
+  public void setIsolationMode(String mode) {
+    if (mode.equals("TRANSACTION_SERIALIZABLE"))
+      this.isolationMode = Connection.TRANSACTION_SERIALIZABLE;
+    else if (mode.equals("TRANSACTION_READ_COMMITTED"))
+      this.isolationMode = Connection.TRANSACTION_READ_COMMITTED;
+    else if (mode.equals("TRANSACTION_REPEATABLE_READ"))
+      this.isolationMode = Connection.TRANSACTION_REPEATABLE_READ;
+    else if (mode.equals("TRANSACTION_READ_UNCOMMITTED"))
+      this.isolationMode = Connection.TRANSACTION_READ_UNCOMMITTED;
+    else if (!mode.isEmpty())
+      System.out.println("Indefined isolation mode, set to default [TRANSACTION_SERIALIZABLE]");
+  }
 
-	public void setLoaderThreads(int loaderThreads) {
-        this.loaderThreads = loaderThreads;
-    }
+  public boolean getUseKeyingTime() {
+    return useKeyingTime;
+  }
 
-	/**
-	 * The number of loader threads that the framework is allowed to use.
-	 * @return
-	 */
-	public int getLoaderThreads() {
-        return this.loaderThreads;
-    }
+  public void setUseKeyingTime(boolean useKeyingTime) {
+    this.useKeyingTime = useKeyingTime;
+  }
 
-	public int getNumTxnTypes() {
-		return numTxnTypes;
-	}
+  public boolean getUseThinkTime() {
+    return useThinkTime;
+  }
 
-	public void setNumTxnTypes(int numTxnTypes) {
-		this.numTxnTypes = numTxnTypes;
-	}
+  public void setUseThinkTime(boolean useThinkTime) {
+    this.useThinkTime = useThinkTime;
+  }
 
-	public String getDBName() {
-		return db_name;
-	}
+  public boolean getEnableForeignKeysAfterLoad() {
+    return enableForeignKeysAfterLoad;
+  }
 
-	public void setDBUsername(String username) {
-		this.db_username = username;
-	}
+  public void setEnableForeignKeysAfterLoad(boolean enableForeignKeysAfterLoad) {
+    this.enableForeignKeysAfterLoad = enableForeignKeysAfterLoad;
+  }
 
-	public String getDBUsername() {
-		return db_username;
-	}
+  public int getBatchSize() {
+    return batchSize;
+  }
 
-	public void setDBPassword(String password) {
-		this.db_password = password;
-	}
+  public void setBatchSize(int batchSize) {
+    this.batchSize = batchSize;
+  }
 
-	public String getDBPassword() {
-		return this.db_password;
-	}
-
-	public void setSelectivity(double selectivity) {
-        this.selectivity = selectivity;
-    }
-
-	public double getSelectivity() {
-	    return this.selectivity;
-	}
-
-	public void setDBDriver(String driver) {
-		this.db_driver = driver;
-	}
-
-	public String getDBDriver() {
-		return this.db_driver;
-	}
-
-	public void setRecordAbortMessages(boolean recordAbortMessages) {
-        this.recordAbortMessages = recordAbortMessages;
-    }
-
-	/**
-	 * Whether each worker should record the transaction's UserAbort messages
-	 * This primarily useful for debugging a benchmark
-	 */
-	public boolean getRecordAbortMessages() {
-        return (this.recordAbortMessages);
-    }
-
-	/**
-	 * Set the scale factor for the database
-	 * A value of 1 means the default size.
-	 * A value greater than 1 means the database is larger
-	 * A value less than 1 means the database is smaller
-	 * @param scaleFactor
-	 */
-	public void setScaleFactor(double scaleFactor) {
-        this.scaleFactor = scaleFactor;
-    }
-	/**
-	 * Return the scale factor of the database size
-	 * @return
-	 */
-	public double getScaleFactor() {
-        return this.scaleFactor;
-    }
-
-	/**
-	 * Return the number of phases specified in the config file
-	 * @return
-	 */
-	public int getNumberOfPhases() {
-		return this.numberOfPhases;
-	}
-
-	/**
-     * Set the directory in which we can find the data files (for example, CSV
-     * files) for loading the database.
-     */
-    public void setDataDir(String dir) {
-        this.dataDir = dir;
-    }
-
-    /**
-     * Return the directory in which we can find the data files (for example, CSV
-     * files) for loading the database.
-     */
-    public String getDataDir() {
-        return this.dataDir;
-    }
-
-    /**
-	 * A utility method that init the phaseIterator and dialectMap
-	 */
-	public void init() {
-	    try {
-	        Class.forName(this.db_driver);
-	    } catch (ClassNotFoundException ex) {
-	        throw new RuntimeException("Failed to initialize JDBC driver '" + this.db_driver + "'", ex);
-	    }
-	}
-
-	public void setTerminals(int terminals) {
-		this.terminals = terminals;
-	}
-
-	public int getTerminals() {
-		return terminals;
-	}
-
-	public void setNumDBConnections(int numDBConnections) { this.numDBConnections = numDBConnections; }
-
-	public int getNumDBConnections() { return this.numDBConnections; }
-
-	public void setPort(int port) { this.port = port; }
-
-	public int getPort() { return port; }
-
-	public TransactionTypes getTransTypes() {
-		return transTypes;
-	}
-
-	public void setTransTypes(TransactionTypes transTypes) {
-		this.transTypes = transTypes;
-	}
-
-	public List<Phase> getAllPhases() {
-		return works;
-	}
-
-	public void setXmlConfig(XMLConfiguration xmlConfig) {
-		this.xmlConfig = xmlConfig;
-	}
-
-	public XMLConfiguration getXmlConfig() {
-		return xmlConfig;
-	}
-
-	public int getIsolationMode() {
-		return isolationMode;
-	}
-
-    public String getIsolationString() {
-        if(this.isolationMode== Connection.TRANSACTION_SERIALIZABLE)
-            return "TRANSACTION_SERIALIZABLE";
-        else if(this.isolationMode==Connection.TRANSACTION_READ_COMMITTED)
-            return "TRANSACTION_READ_COMMITTED";
-        else if(this.isolationMode==Connection.TRANSACTION_REPEATABLE_READ)
-            return "TRANSACTION_REPEATABLE_READ";
-        else if(this.isolationMode==Connection.TRANSACTION_READ_UNCOMMITTED)
-            return "TRANSACTION_READ_UNCOMMITTED";
-        else
-            return "TRANSACTION_SERIALIZABLE [DEFAULT]";
-    }
-
-	public void setIsolationMode(String mode) {
-		if(mode.equals("TRANSACTION_SERIALIZABLE"))
-			this.isolationMode= Connection.TRANSACTION_SERIALIZABLE;
-		else if(mode.equals("TRANSACTION_READ_COMMITTED"))
-			this.isolationMode=Connection.TRANSACTION_READ_COMMITTED;
-		else if(mode.equals("TRANSACTION_REPEATABLE_READ"))
-			this.isolationMode=Connection.TRANSACTION_REPEATABLE_READ;
-		else if(mode.equals("TRANSACTION_READ_UNCOMMITTED"))
-			this.isolationMode=Connection.TRANSACTION_READ_UNCOMMITTED;
-		else if(!mode.isEmpty())
-			System.out.println("Indefined isolation mode, set to default [TRANSACTION_SERIALIZABLE]");
-	}
-
-    public boolean getUseKeyingTime() {
-      return useKeyingTime;
-    }
-
-    public void setUseKeyingTime(boolean useKeyingTime) {
-      this.useKeyingTime = useKeyingTime;
-    }
-
-    public boolean getUseThinkTime() {
-      return useThinkTime;
-    }
-
-    public void setUseThinkTime(boolean useThinkTime) {
-      this.useThinkTime = useThinkTime;
-    }
-
-    public boolean getEnableForeignKeysAfterLoad() {
-      return enableForeignKeysAfterLoad;
-    }
-
-    public void setEnableForeignKeysAfterLoad(boolean enableForeignKeysAfterLoad) {
-      this.enableForeignKeysAfterLoad = enableForeignKeysAfterLoad;
-    }
-
-    public int getBatchSize() {
-      return batchSize;
-    }
-
-    public void setBatchSize(int batchSize) {
-      this.batchSize = batchSize;
-    }
-
-	@Override
-	public String toString() {
-        Class<?> confClass = this.getClass();
-        Map<String, Object> m = new ListOrderedMap<String, Object>();
-        for (Field f : confClass.getDeclaredFields()) {
-            Object obj = null;
-            try {
-                obj = f.get(this);
-            } catch (IllegalAccessException ex) {
-                throw new RuntimeException(ex);
-            }
-            m.put(f.getName().toUpperCase(), obj);
-        } // FOR
-        return StringUtil.formatMaps(m);
-    }
+  @Override
+  public String toString() {
+    Class<?> confClass = this.getClass();
+    Map<String, Object> m = new ListOrderedMap<String, Object>();
+    for (Field f : confClass.getDeclaredFields()) {
+      Object obj = null;
+      try {
+        obj = f.get(this);
+      } catch (IllegalAccessException ex) {
+        throw new RuntimeException(ex);
+      }
+      m.put(f.getName().toUpperCase(), obj);
+    } // FOR
+    return StringUtil.formatMaps(m);
+  }
 }

--- a/src/com/oltpbenchmark/api/BenchmarkModule.java
+++ b/src/com/oltpbenchmark/api/BenchmarkModule.java
@@ -91,7 +91,7 @@ public abstract class BenchmarkModule {
      */
     private final Random rng = new Random();
 
-    public BenchmarkModule(String benchmarkName, WorkloadConfiguration workConf, boolean withCatalog) {
+    public BenchmarkModule(String benchmarkName, WorkloadConfiguration workConf, boolean withCatalog) throws Exception {
         assert (workConf != null) : "The WorkloadConfiguration instance is null.";
 
         this.benchmarkName = benchmarkName;
@@ -104,13 +104,15 @@ public abstract class BenchmarkModule {
             createDataSource();
         } catch (Exception e) {
             LOG.error("Failed to create Data source", e);
+            throw e;
         }
     }
 
     private List<HikariDataSource> listDataSource = new ArrayList<>();
 
     public void createDataSource() throws SQLException {
-        int numConnections = workConf.getNumDBConnections() / workConf.getNodes().size();
+        int numConnections =
+            (workConf.getNumDBConnections() + workConf.getNodes().size() - 1) / workConf.getNodes().size();
         for (String ip : workConf.getNodes()) {
             Properties props = new Properties();
             props.setProperty("dataSourceClassName", "org.postgresql.ds.PGSimpleDataSource");

--- a/src/com/oltpbenchmark/api/BenchmarkModule.java
+++ b/src/com/oltpbenchmark/api/BenchmarkModule.java
@@ -130,7 +130,7 @@ public abstract class BenchmarkModule {
 
     private static AtomicInteger dataSourceCounter = new AtomicInteger(0);
     public final HikariDataSource getDataSource() {
-        int r =  dataSourceCounter.getAndIncrement() % workConf.getNodes().size();
+        int r = dataSourceCounter.getAndIncrement() % workConf.getNodes().size();
         return listDataSource.get(r);
     }
 

--- a/src/com/oltpbenchmark/api/Loader.java
+++ b/src/com/oltpbenchmark/api/Loader.java
@@ -57,7 +57,7 @@ public abstract class Loader<T extends BenchmarkModule> {
         @Override
         public final void run() {
             try {
-                Connection conn = Loader.this.benchmark.makeConnection();
+                Connection conn = Loader.this.benchmark.getDataSource().getConnection();
                 conn.setAutoCommit(false);
 
                 this.load(conn);

--- a/src/com/oltpbenchmark/api/Worker.java
+++ b/src/com/oltpbenchmark/api/Worker.java
@@ -643,7 +643,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
      * @throws SQLException
      *             TODO
      */
-    protected abstract TransactionStatus executeWork(Connection conn,TransactionType txnType) throws UserAbortException, SQLException;
+    protected abstract TransactionStatus executeWork(Connection conn, TransactionType txnType) throws UserAbortException, SQLException;
 
     /**
      * Called at the end of the test to do any clean up that may be required.

--- a/src/com/oltpbenchmark/api/Worker.java
+++ b/src/com/oltpbenchmark/api/Worker.java
@@ -26,6 +26,9 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
+
+import com.zaxxer.hikari.HikariDataSource;
+
 import org.apache.log4j.Logger;
 
 import com.oltpbenchmark.LatencyRecord;
@@ -53,7 +56,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
 
     private final int id;
     private final T benchmarkModule;
-    protected final Connection conn;
+    protected final HikariDataSource dataSource;
     protected final WorkloadConfiguration wrkld;
     protected final TransactionTypes transactionTypes;
     protected final Map<TransactionType, Procedure> procedures = new HashMap<TransactionType, Procedure>();
@@ -78,16 +81,8 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
         assert (this.transactionTypes != null) : "The TransactionTypes from the WorkloadConfiguration is null!";
 
         try {
-            this.conn = this.benchmarkModule.makeConnection();
-            this.conn.setAutoCommit(false);
-
-            // 2018-01-11: Since we want to support NoSQL systems
-            // that do not support txns, we will not invoke certain JDBC functions
-            // that may cause an error in them.
-            if (this.wrkld.getDBType().shouldUseTransactions()) {
-                this.conn.setTransactionIsolation(this.wrkld.getIsolationMode());
-            }
-        } catch (SQLException ex) {
+            this.dataSource = this.benchmarkModule.getDataSource();
+        } catch (Exception ex) {
             throw new RuntimeException("Failed to connect to database", ex);
         }
 
@@ -140,10 +135,6 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
 
     public final Random rng() {
         return (this.benchmarkModule.rng());
-    }
-
-    public final Connection getConnection() {
-        return (this.conn);
     }
 
     public final int getRequests() {
@@ -445,7 +436,13 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
         final DatabaseType dbType = wrkld.getDBType();
         final boolean recordAbortMessages = wrkld.getRecordAbortMessages();
 
+
+        Connection conn = null;
         try {
+            conn = dataSource.getConnection();
+            conn.setAutoCommit(false);
+            conn.setTransactionIsolation(this.wrkld.getIsolationMode());
+
             while (status == TransactionStatus.RETRY && this.wrkldState.getGlobalState() != State.DONE) {
                 if (next == null) {
                     next = transactionTypes.getType(pieceOfWork.getType());
@@ -462,7 +459,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
                     // }
 
                     status = TransactionStatus.UNKNOWN;
-                    status = this.executeWork(next);
+                    status = this.executeWork(conn, next);
 
                 // User Abort Handling
                 // These are not errors
@@ -481,9 +478,9 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
                     }
 
                     if (savepoint != null) {
-                        this.conn.rollback(savepoint);
+                        conn.rollback(savepoint);
                     } else {
-                        this.conn.rollback();
+                        conn.rollback();
                     }
 
                     status = TransactionStatus.USER_ABORTED;
@@ -502,9 +499,9 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
 
 		    if (this.wrkld.getDBType().shouldUseTransactions()) {
 			if (savepoint != null) {
-			    this.conn.rollback(savepoint);
+			    conn.rollback(savepoint);
 			} else {
-			    this.conn.rollback();
+			    conn.rollback();
 			}
 		    }
 
@@ -607,6 +604,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
                 }
 
             } // WHILE
+            conn.close();
         } catch (SQLException ex) {
             String msg = String.format("Unexpected fatal, error in '%s' when executing '%s' [%s]",
                                        this, next, dbType);
@@ -645,7 +643,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
      * @throws SQLException
      *             TODO
      */
-    protected abstract TransactionStatus executeWork(TransactionType txnType) throws UserAbortException, SQLException;
+    protected abstract TransactionStatus executeWork(Connection conn,TransactionType txnType) throws UserAbortException, SQLException;
 
     /**
      * Called at the end of the test to do any clean up that may be required.
@@ -653,13 +651,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
      * @param error
      *            TODO
      */
-    public void tearDown(boolean error) {
-        try {
-            conn.close();
-        } catch (SQLException e) {
-            LOG.warn("No connection to close");
-        }
-    }
+    public void tearDown(boolean error) { }
 
     public void initializeState() {
         assert (this.wrkldState == null);

--- a/src/com/oltpbenchmark/api/collectors/DBCollector.java
+++ b/src/com/oltpbenchmark/api/collectors/DBCollector.java
@@ -104,7 +104,7 @@ public abstract class DBCollector {
     public static DBCollector createCollector(WorkloadConfiguration workConf) {
         return createCollector(
                 workConf.getDBType(),
-                workConf.getDBConnections().get(0),
+                workConf.getNodes().get(0),
                 workConf.getDBUsername(),
                 workConf.getDBPassword());
     }

--- a/src/com/oltpbenchmark/benchmarks/tpcc/TPCCWorker.java
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/TPCCWorker.java
@@ -68,7 +68,7 @@ public class TPCCWorker extends Worker<TPCCBenchmark> {
 	 * Executes a single TPCC transaction of type transactionType.
 	 */
 	@Override
-    protected TransactionStatus executeWork(Connection conn,TransactionType nextTransaction) throws UserAbortException, SQLException {
+    protected TransactionStatus executeWork(Connection conn, TransactionType nextTransaction) throws UserAbortException, SQLException {
         try {
             TPCCProcedure proc = (TPCCProcedure) this.getProcedure(nextTransaction.getProcedureClass());
 

--- a/src/com/oltpbenchmark/benchmarks/tpcc/TPCCWorker.java
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/TPCCWorker.java
@@ -25,6 +25,7 @@ package com.oltpbenchmark.benchmarks.tpcc;
  *
  */
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Random;
 
@@ -67,7 +68,7 @@ public class TPCCWorker extends Worker<TPCCBenchmark> {
 	 * Executes a single TPCC transaction of type transactionType.
 	 */
 	@Override
-    protected TransactionStatus executeWork(TransactionType nextTransaction) throws UserAbortException, SQLException {
+    protected TransactionStatus executeWork(Connection conn,TransactionType nextTransaction) throws UserAbortException, SQLException {
         try {
             TPCCProcedure proc = (TPCCProcedure) this.getProcedure(nextTransaction.getProcedureClass());
 


### PR DESCRIPTION
Summary:
We need 10X the number of terminals with respect to the number of
warehouses to get a good TPM-C number. Each terminal gets its own
connection to perform transactions. This is fine for smaller number of
warehouses. But as the number increases, we reach the limit of the max
number of connections supported by the DB.

Given that each terminal spends most of its time waiting for keying or
for thinking, we could reuse the connections across the terminals.

This change creates a Hikari pool one per endpoint and each worker gets
a reference to the pool rather than an actual connection. When the
worker executes a transaction, it gets a connection from the pool and
 gives the connection back to the pool once the transaction is done.

Each worker prepares a statement every time it executes a transaction.
This is fine since the driver has a cache of PreparedStatements per
connection of size 256. The number of unique statements in the
application is 33. Hence we don't send the PrepareStatement requests to
the server every time.

Reviewers:
Neha, Mikhail, Karthik