### PR TITLE
Ignore the thread waiting time in the calculation of TPM-C.

### DIFF
--- a/src/com/oltpbenchmark/DBWorkload.java
+++ b/src/com/oltpbenchmark/DBWorkload.java
@@ -882,10 +882,9 @@ public class DBWorkload {
         long tpmc = numNewOrderTransactions * 60 / time;
         double efficiency = 1.0 * tpmc * 100 / numWarehouses / 12.86;
 
-        LOG.info("Num New Order transactions : " + numNewOrderTransactions +
-                 " time seconds: " + time +
-                 " TPM-C: " + tpmc +
-                 " Efficiency : " + efficiency);
+        LOG.info("Num New Order transactions : " + numNewOrderTransactions + " time seconds: " + time);
+        LOG.info("TPM-C: " + tpmc);
+        LOG.info("Efficiency : " + efficiency);
         return r;
     }
 

--- a/src/com/oltpbenchmark/DBWorkload.java
+++ b/src/com/oltpbenchmark/DBWorkload.java
@@ -882,7 +882,7 @@ public class DBWorkload {
         long tpmc = numNewOrderTransactions * 60 / time;
         double efficiency = 1.0 * tpmc * 100 / numWarehouses / 12.86;
 
-        LOG.info("Num New Order transactions : " + numNewOrderTransactions + " time seconds: " + time);
+        LOG.info("Num New Order transactions : " + numNewOrderTransactions + ", time seconds: " + time);
         LOG.info("TPM-C: " + tpmc);
         LOG.info("Efficiency : " + efficiency);
         return r;

--- a/src/com/oltpbenchmark/DBWorkload.java
+++ b/src/com/oltpbenchmark/DBWorkload.java
@@ -63,6 +63,7 @@ public class DBWorkload {
 
     private static int newOrderTxnId = -1;
     private static int numWarehouses = -1;
+    private static int time = -1;
 
     /**
      * @param args
@@ -464,7 +465,7 @@ public class DBWorkload {
                     System.exit(-1);
                 }
 
-                int time = work.getInt("/time", 0);
+                time = work.getInt("/time", 0);
                 int warmup = work.getInt("/warmup", 0);
                 timed = (time > 0);
                 if (scriptRun) {
@@ -853,6 +854,7 @@ public class DBWorkload {
         List<WorkloadConfiguration> workConfs = new ArrayList<WorkloadConfiguration>();
 
         long start = System.nanoTime();
+        long end = start + Long.valueOf(time) * 1000 * 1000 * 1000;
         for (BenchmarkModule bench : benchList) {
             LOG.info("Creating " + bench.getWorkloadConfiguration().getTerminals() + " virtual terminals...");
             workers.addAll(bench.makeWorkers(verbose));
@@ -865,12 +867,11 @@ public class DBWorkload {
 
         }
         Results r = ThreadBench.runRateLimitedBenchmark(workers, workConfs, intervalMonitor);
-        long end = System.nanoTime();
 
         long numNewOrderTransactions = 0;
         for (Worker<?> w : workers) {
             for (LatencyRecord.Sample sample : w.getLatencyRecords()) {
-                if (sample.tranType == newOrderTxnId) {
+                if (sample.tranType == newOrderTxnId && sample.startNs + 1000L * sample.latencyUs <= end) {
                     ++numNewOrderTransactions;
                 }
             }
@@ -878,14 +879,13 @@ public class DBWorkload {
         LOG.info(SINGLE_LINE);
         LOG.info("Rate limited reqs/s: " + r);
 
-        long time_seconds = (end - start) / 1000 / 1000 / 1000;
-        long tpmc = numNewOrderTransactions * 60 * 1000 * 1000 * 1000 / (end - start);
+        long tpmc = numNewOrderTransactions * 60 / time;
         double efficiency = 1.0 * tpmc * 100 / numWarehouses / 12.86;
 
         LOG.info("Num New Order transactions : " + numNewOrderTransactions +
-                 " time seconds: " + time_seconds +
+                 " time seconds: " + time +
                  " TPM-C: " + tpmc +
-                 " Efficienccy : " + efficiency);
+                 " Efficiency : " + efficiency);
         return r;
     }
 

--- a/src/com/oltpbenchmark/LatencyRecord.java
+++ b/src/com/oltpbenchmark/LatencyRecord.java
@@ -102,7 +102,6 @@ public class LatencyRecord implements Iterable<LatencyRecord.Sample> {
 	private final class LatencyRecordIterator implements Iterator<Sample> {
 		private int chunkIndex = 0;
 		private int subIndex = 0;
-		//private long lastIteratorNs = startNs;
 
 		@Override
 		public boolean hasNext() {

--- a/src/com/oltpbenchmark/LatencyRecord.java
+++ b/src/com/oltpbenchmark/LatencyRecord.java
@@ -27,45 +27,27 @@ public class LatencyRecord implements Iterable<LatencyRecord.Sample> {
 
 	/**
 	 * Contains (start time, latency, transactionType, workerid, phaseid) pentiplets 
-	 * in microsecond form. The start times are "compressed" by encoding them as 
-	 * increments, starting from startNs. A 32-bit integer provides sufficient resolution
-	 * for an interval of 2146 seconds, or 35 minutes.
+	 * in microsecond form. 
 	 */
 	private final ArrayList<Sample[]> values = new ArrayList<Sample[]>();
 	private int nextIndex;
 
-	private final long startNs;
-	private long lastNs;
-
 	public LatencyRecord(long startNs) {
 		assert startNs > 0;
-
-		this.startNs = startNs;
-		lastNs = startNs;
 		allocateChunk();
-
 	}
 
     public void addLatency(int transType, long startNs, long endNs, int workerId, int phaseId) {
-		assert lastNs > 0;
-		assert lastNs - 500 <= startNs;
 		assert endNs >= startNs;
-
 		if (nextIndex == ALLOC_SIZE) {
 			allocateChunk();
 		}
 		Sample[] chunk = values.get(values.size() - 1);
-
-		long startOffsetNs = (startNs - lastNs + 500);
-		assert startOffsetNs >= 0;
 		int latencyUs = (int) ((endNs - startNs + 500) / 1000);
 		assert latencyUs >= 0;
 
-		chunk[nextIndex] = new Sample(transType, startOffsetNs, latencyUs
-				, workerId, phaseId);
+		chunk[nextIndex] = new Sample(transType, startNs, latencyUs, workerId, phaseId);
 		++nextIndex;
-
-		lastNs += startOffsetNs;
 	}
 
 	private void allocateChunk() {
@@ -120,7 +102,7 @@ public class LatencyRecord implements Iterable<LatencyRecord.Sample> {
 	private final class LatencyRecordIterator implements Iterator<Sample> {
 		private int chunkIndex = 0;
 		private int subIndex = 0;
-		private long lastIteratorNs = startNs;
+		//private long lastIteratorNs = startNs;
 
 		@Override
 		public boolean hasNext() {
@@ -149,12 +131,6 @@ public class LatencyRecord implements Iterable<LatencyRecord.Sample> {
 				chunkIndex += 1;
 				subIndex = 0;
 			}
-
-			// Previously, s.startNs was just an offset from the previous
-			// value.  Now we make it an absolute.
-			s.startNs += lastIteratorNs;
-			lastIteratorNs = s.startNs;
-
 			return s;
 		}
 


### PR DESCRIPTION
Summary:
For the calculation of TPM-C we used the entire duration of the run
which included the waiting time of the trailing transactions.

With this change, we ignore the transactions that complete after the
configured time and use the configured time for the calculation of
TPM-C.

Reviewers:
Neha