### PR TITLE
Adding HikariPool to pom.xml for editors like Intellij.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,11 @@
             <artifactId>jaxb-impl</artifactId>
             <version>2.3.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>3.4.5</version>
+        </dependency>
 
         <!--
             Because this isn't an open source jar this is required:


### PR DESCRIPTION
Summary:
We need an entry for the HikariPool in the pom.xml along with the entry
in ivy.xml so that editors like Intellij can recognize it.

Reviewers:
Neha