### PR TITLE
Making configuration easier for the benchmark.

### DIFF
--- a/config/workload_all.xml
+++ b/config/workload_all.xml
@@ -2,26 +2,18 @@
 <parameters>
     <dbtype>postgres</dbtype>
     <driver>org.postgresql.Driver</driver>
-    <nodes>
-      <!-- Add as many node entries as the number of nodes present.  -->
-      <node>127.0.0.1</node>
-    </nodes>
+    <port>5433</port>
     <username>yugabyte</username>
     <DBName>yugabyte</DBName>
     <password></password>
     <isolation>TRANSACTION_REPEATABLE_READ</isolation>
 
-    <!-- The number of warehouses -->
-    <scalefactor>10</scalefactor>
-    <!-- Number of threads used for loading data -->
-    <loaderThreads>10</loaderThreads>
-    <!-- TPC-C 4.2.2: The number of terminals should be 10 per warehouse -->
+    <!--
     <terminals>100</terminals>
-    <batchSize>128</batchSize>
-
-      <!-- The actual number of connections used  -->
     <numDBConnections>10</numDBConnections>
+    -->
 
+    <batchSize>128</batchSize>
     <useKeyingTime>true</useKeyingTime>
     <useThinkTime>true</useThinkTime>
     <enableForeignKeysAfterLoad>true</enableForeignKeysAfterLoad>


### PR DESCRIPTION
Summary:
Currently for running the benchmark we will have to configure a lot of
parameters in the config file and then run the benchmark.

With this change we can run the workload by specifying the list of nodes
and the number of warehouses.
example load:
./tpccbenchmark --create=true --load=true
./tpccbenchmark --create=true --load=true --nodes=127.0.0.1,127.0.0.2
./tpccbenchmark --create=true --load=true --nodes=127.0.0.1,127.0.0.2 --warehouses=20 --loaderthreads=20

example execute:
./tpccbenchmark --execute=true
./tpccbenchmark --execute=true --nodes=127.0.0.1,127.0.0.2
./tpccbenchmark --execute=true --nodes=127.0.0.1,127.0.0.2 --warehouses=20

The default values for
nodes -> 127.0.0.1
warehouses -> 10
loaderthreads -> 10
terminals -> 10 * warehouses
DBconnections -> warehouses

The values for terminals and DBconnections can be further tweaked in the
config file.

Reviewers:
Neha, Karthik