### PR TITLE
Sharded TPCC

### DIFF
--- a/config/workload_all.xml
+++ b/config/workload_all.xml
@@ -10,14 +10,13 @@
 
     <!--
     <terminals>100</terminals>
-    <numDBConnections>10</numDBConnections>
     -->
 
     <batchSize>128</batchSize>
     <useKeyingTime>true</useKeyingTime>
     <useThinkTime>true</useThinkTime>
     <enableForeignKeysAfterLoad>true</enableForeignKeysAfterLoad>
-    <hikariConnectionTimeoutMs>60000</hikariConnectionTimeoutMs>
+    <hikariConnectionTimeoutMs>180000</hikariConnectionTimeoutMs>
    	<transactiontypes>
     	<transactiontype>
     		<name>NewOrder</name>

--- a/src/com/oltpbenchmark/Results.java
+++ b/src/com/oltpbenchmark/Results.java
@@ -157,11 +157,10 @@ public final class Results {
         };
         out.println(StringUtil.join(",", header));
         for (Sample s : latencySamples) {
-            double startUs = ((double) s.startNs / (double) 1000000000);
+            double startSec = ((double) s.startNs / (double) 1000000000);
             String row[] = {
                 activeTXTypes.get(s.tranType-1).getName(),
-                String.format("%10.6f", startUs - offset),
-                Integer.toString(s.operationLatencyUs),
+                String.format("%10.6f", startSec),
             };
             out.println(StringUtil.join(",", row));
         }

--- a/src/com/oltpbenchmark/ThreadBench.java
+++ b/src/com/oltpbenchmark/ThreadBench.java
@@ -337,6 +337,7 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
 
         for (WorkloadState workState : this.workStates) {
             workState.switchToNextPhase();
+            workState.setPhaseStartTime(start);
             phase = workState.getCurrentPhase();
             LOG.info(phase.currentPhaseString());
             if (phase.rate < lowestRate) {
@@ -436,6 +437,7 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
                     for (WorkloadState workState : workStates) {
                         synchronized (workState) {
                             workState.switchToNextPhase();
+                            workState.setPhaseStartTime(now);
                             lowestRate = Integer.MAX_VALUE;
                             phase = workState.getCurrentPhase();
                             interruptWorkers();

--- a/src/com/oltpbenchmark/WorkloadConfiguration.java
+++ b/src/com/oltpbenchmark/WorkloadConfiguration.java
@@ -48,9 +48,9 @@ public class WorkloadConfiguration {
   private String db_username;
   private String db_password;
   private String db_driver;
-  private int scaleFactor = -1;
-  private int startWarehouseId = -1;
-  private int totalWarehousesAcrossExecutions = -1;
+  private int numWarehouses = -1;
+  private int startWarehouseIdForShard = -1;
+  private int totalWarehousesAcrossShards = -1;
   private double selectivity = -1.0;
   private int terminals;
   private int numDBConnections = -1;
@@ -192,25 +192,11 @@ public class WorkloadConfiguration {
     return (this.recordAbortMessages);
   }
 
-  /**
-   * Set the scale factor for the database
-   * A value of 1 means the default size.
-   * A value greater than 1 means the database is larger
-   * A value less than 1 means the database is smaller
-   *
-   * @param scaleFactor
-   */
-  public void setScaleFactor(int scaleFactor) {
-    this.scaleFactor = scaleFactor;
+  public void setNumWarehouses(int warehouses) {
+    this.numWarehouses = warehouses;
   }
-
-  /**
-   * Return the scale factor of the database size
-   *
-   * @return
-   */
-  public int getScaleFactor() {
-    return this.scaleFactor;
+  public int getNumWarehouses() {
+    return this.numWarehouses;
   }
 
   /**
@@ -261,18 +247,18 @@ public class WorkloadConfiguration {
     this.numDBConnections = numDBConnections;
   }
 
-  public void setStartWarehouseId(int startWarehoue) {
-    this.startWarehouseId = startWarehoue;
+  public void setStartWarehouseIdForShard(int startWarehoue) {
+    this.startWarehouseIdForShard = startWarehoue;
   }
-  public int getStartWarehouseId() {
-    return this.startWarehouseId;
+  public int getStartWarehouseIdForShard() {
+    return this.startWarehouseIdForShard;
   }
 
-  public void setTotalWarehousesAcrossExecutions(int totalWarehousesAcrossExecutions) {
-    this.totalWarehousesAcrossExecutions = totalWarehousesAcrossExecutions;
+  public void setTotalWarehousesAcrossShards(int totalWarehousesAcrossExecutions) {
+    this.totalWarehousesAcrossShards = totalWarehousesAcrossExecutions;
   }
-  public int getTotalWarehousesAcrossExecutions() {
-    return this.totalWarehousesAcrossExecutions;
+  public int getTotalWarehousesAcrossShards() {
+    return this.totalWarehousesAcrossShards;
   }
 
   public int getNumDBConnections() {

--- a/src/com/oltpbenchmark/WorkloadConfiguration.java
+++ b/src/com/oltpbenchmark/WorkloadConfiguration.java
@@ -48,7 +48,9 @@ public class WorkloadConfiguration {
   private String db_username;
   private String db_password;
   private String db_driver;
-  private double scaleFactor = 1.0;
+  private int scaleFactor = -1;
+  private int startWarehouseId = -1;
+  private int totalWarehousesAcrossExecutions = -1;
   private double selectivity = -1.0;
   private int terminals;
   private int numDBConnections = -1;
@@ -59,6 +61,7 @@ public class WorkloadConfiguration {
   private boolean useKeyingTime = true;
   private boolean useThinkTime = true;
   private boolean enableForeignKeysAfterLoad = true;
+  private boolean shouldEnableForeignKeys = true;
   private int batchSize = 128;
   private int hikariConnectionTimeout = 60000;
   private boolean needsExecution = false;
@@ -197,7 +200,7 @@ public class WorkloadConfiguration {
    *
    * @param scaleFactor
    */
-  public void setScaleFactor(double scaleFactor) {
+  public void setScaleFactor(int scaleFactor) {
     this.scaleFactor = scaleFactor;
   }
 
@@ -206,7 +209,7 @@ public class WorkloadConfiguration {
    *
    * @return
    */
-  public double getScaleFactor() {
+  public int getScaleFactor() {
     return this.scaleFactor;
   }
 
@@ -256,6 +259,20 @@ public class WorkloadConfiguration {
 
   public void setNumDBConnections(int numDBConnections) {
     this.numDBConnections = numDBConnections;
+  }
+
+  public void setStartWarehouseId(int startWarehoue) {
+    this.startWarehouseId = startWarehoue;
+  }
+  public int getStartWarehouseId() {
+    return this.startWarehouseId;
+  }
+
+  public void setTotalWarehousesAcrossExecutions(int totalWarehousesAcrossExecutions) {
+    this.totalWarehousesAcrossExecutions = totalWarehousesAcrossExecutions;
+  }
+  public int getTotalWarehousesAcrossExecutions() {
+    return this.totalWarehousesAcrossExecutions;
   }
 
   public int getNumDBConnections() {
@@ -350,6 +367,13 @@ public class WorkloadConfiguration {
 
   public void setEnableForeignKeysAfterLoad(boolean enableForeignKeysAfterLoad) {
     this.enableForeignKeysAfterLoad = enableForeignKeysAfterLoad;
+  }
+
+  public boolean getShouldEnableForeignKeys() {
+    return this.shouldEnableForeignKeys;
+  }
+  public void setShouldEnableForeignKeys(boolean shouldEnableForeignKeys) {
+    this.shouldEnableForeignKeys = shouldEnableForeignKeys;
   }
 
   public int getBatchSize() {

--- a/src/com/oltpbenchmark/WorkloadState.java
+++ b/src/com/oltpbenchmark/WorkloadState.java
@@ -48,6 +48,8 @@ public class WorkloadState {
     private Phase currentPhase = null;
     private long phaseStartNs = 0;
     private TraceReader traceReader = null;
+
+    private long phaseStartTime = 0;
     
     public WorkloadState(BenchmarkState benchmarkState, List<Phase> works, int num_terminals, TraceReader traceReader) {
         this.benchmarkState = benchmarkState;
@@ -244,6 +246,9 @@ public class WorkloadState {
             this.notifyAll();
        }
    }
+
+   public void setPhaseStartTime(long startTime) { this.phaseStartTime = startTime; }
+   public long getPhaseStartTime() { return this.phaseStartTime; }
    
    /**
     * Delegates pre-start blocking to the global state handler

--- a/src/com/oltpbenchmark/api/BenchmarkModule.java
+++ b/src/com/oltpbenchmark/api/BenchmarkModule.java
@@ -474,6 +474,8 @@ public abstract class BenchmarkModule {
         return (proc_xref);
     }
 
+    public abstract void enableForeignKeys() throws Exception;
+
     /**
      *
      * @param procClass

--- a/src/com/oltpbenchmark/api/BenchmarkModule.java
+++ b/src/com/oltpbenchmark/api/BenchmarkModule.java
@@ -116,6 +116,10 @@ public abstract class BenchmarkModule {
         int numConnections =
             (workConf.getNumDBConnections() + workConf.getNodes().size() - 1) / workConf.getNodes().size();
         for (String ip : workConf.getNodes()) {
+            // Sleep for some time so as to allow the postgres process to cache the system information.
+            if (listDataSource.size() != 0) {
+                ThreadUtil.sleep(5000);
+            }
             Properties props = new Properties();
             props.setProperty("dataSourceClassName", "org.postgresql.ds.PGSimpleDataSource");
             props.setProperty("dataSource.serverName", ip);

--- a/src/com/oltpbenchmark/api/Loader.java
+++ b/src/com/oltpbenchmark/api/Loader.java
@@ -32,6 +32,7 @@ import com.oltpbenchmark.catalog.Table;
 import com.oltpbenchmark.types.DatabaseType;
 import com.oltpbenchmark.util.Histogram;
 import com.oltpbenchmark.util.SQLUtil;
+import org.hibernate.hql.ast.SqlASTFactory;
 
 /**
  * @author pavlo
@@ -41,7 +42,7 @@ public abstract class Loader<T extends BenchmarkModule> {
 
     protected final T benchmark;
     protected final WorkloadConfiguration workConf;
-    protected final double scaleFactor;
+    protected final int numWarehouses;
     private final Histogram<String> tableSizes = new Histogram<String>(true);
 
     /**
@@ -51,7 +52,7 @@ public abstract class Loader<T extends BenchmarkModule> {
      */
     public abstract class LoaderThread implements Runnable {
 
-        public LoaderThread() {
+        public LoaderThread() throws SQLException {
         }
 
         @Override
@@ -84,7 +85,7 @@ public abstract class Loader<T extends BenchmarkModule> {
     public Loader(T benchmark) {
         this.benchmark = benchmark;
         this.workConf = benchmark.getWorkloadConfiguration();
-        this.scaleFactor = workConf.getScaleFactor();
+        this.numWarehouses = workConf.getScaleFactor();
     }
 
     /**

--- a/src/com/oltpbenchmark/api/Loader.java
+++ b/src/com/oltpbenchmark/api/Loader.java
@@ -85,7 +85,7 @@ public abstract class Loader<T extends BenchmarkModule> {
     public Loader(T benchmark) {
         this.benchmark = benchmark;
         this.workConf = benchmark.getWorkloadConfiguration();
-        this.numWarehouses = workConf.getScaleFactor();
+        this.numWarehouses = workConf.getNumWarehouses();
     }
 
     /**

--- a/src/com/oltpbenchmark/api/Worker.java
+++ b/src/com/oltpbenchmark/api/Worker.java
@@ -278,27 +278,6 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
                 think_time_msecs = getThinkTimeInMillis(transactionTypes.getType(pieceOfWork.getType()));
             }
 
-            if (preState == State.WARMUP ) {
-                long operation_end_time = start + (keying_time_msecs + think_time_msecs + 1000) * 1000 * 1000;
-                long warmup_end_time = wrkldState.getPhaseStartTime() + phase.warmupTime * 1000000000L;
-
-                if (operation_end_time > warmup_end_time) {
-                    // Executing this transaction in the warmup period will overflow in to the execution time
-                    // and hence we will not execute this. Sleep until we can start the execution.
-                    long sleep_time = 10;
-                    if (start < warmup_end_time) {
-                        sleep_time = (warmup_end_time - start) / 1000 / 1000;
-                    }
-
-                    try {
-                        Thread.sleep(sleep_time);
-                    } catch (InterruptedException e) {
-                        LOG.error("Thread sleep interrupted");
-                    }
-                    continue;
-                }
-            }
-
             phase = this.wrkldState.getCurrentPhase();
             if (phase == null)
                 continue work;

--- a/src/com/oltpbenchmark/benchmarks/tpcc/TPCCBenchmark.java
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/TPCCBenchmark.java
@@ -71,7 +71,7 @@ public class TPCCBenchmark extends BenchmarkModule {
 
 		TPCCWorker[] terminals = new TPCCWorker[workConf.getTerminals()];
 
-		int numWarehouses = (int) workConf.getScaleFactor();//tpccConf.getNumWarehouses();
+		int numWarehouses = workConf.getScaleFactor();
 		if (numWarehouses <= 0) {
 			numWarehouses = 1;
 		}
@@ -92,7 +92,8 @@ public class TPCCBenchmark extends BenchmarkModule {
 				/ numWarehouses;
 		int workerId = 0;
 		assert terminalsPerWarehouse >= 1;
-		for (int w = 0; w < numWarehouses; w++) {
+		int k = 0;
+		for (int w = workConf.getStartWarehouseId() - 1; w < numWarehouses + workConf.getStartWarehouseId() - 1; w++) {
 			// Compute the number of terminals in *this* warehouse
 			int lowerTerminalId = (int) (w * terminalsPerWarehouse);
 			int upperTerminalId = (int) ((w + 1) * terminalsPerWarehouse);
@@ -122,9 +123,8 @@ public class TPCCBenchmark extends BenchmarkModule {
 				TPCCWorker terminal = new TPCCWorker(this, workerId++,
 						w_id, lowerDistrictId, upperDistrictId,
 						numWarehouses);
-				terminals[lowerTerminalId + terminalId] = terminal;
+				terminals[k++] = terminal;
 			}
-
 		}
 		assert terminals[terminals.length - 1] != null;
 
@@ -151,5 +151,10 @@ public class TPCCBenchmark extends BenchmarkModule {
         }
         return (timestamp);
     }
+
+    public void enableForeignKeys() throws Exception {
+    	TPCCLoader loader = new TPCCLoader(this);
+    	loader.EnableForeignKeyConstraints(makeConnection());
+		}
 
 }

--- a/src/com/oltpbenchmark/benchmarks/tpcc/TPCCBenchmark.java
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/TPCCBenchmark.java
@@ -69,9 +69,10 @@ public class TPCCBenchmark extends BenchmarkModule {
 
 	protected ArrayList<TPCCWorker> createTerminals() throws SQLException {
 
+		// The array 'terminals' contains a terminal associated to a {warehouse, district}.
 		TPCCWorker[] terminals = new TPCCWorker[workConf.getTerminals()];
 
-		int numWarehouses = workConf.getScaleFactor();
+		int numWarehouses = workConf.getNumWarehouses();
 		if (numWarehouses <= 0) {
 			numWarehouses = 1;
 		}
@@ -93,7 +94,7 @@ public class TPCCBenchmark extends BenchmarkModule {
 		int workerId = 0;
 		assert terminalsPerWarehouse >= 1;
 		int k = 0;
-		for (int w = workConf.getStartWarehouseId() - 1; w < numWarehouses + workConf.getStartWarehouseId() - 1; w++) {
+		for (int w = workConf.getStartWarehouseIdForShard() - 1; w < numWarehouses + workConf.getStartWarehouseIdForShard() - 1; w++) {
 			// Compute the number of terminals in *this* warehouse
 			int lowerTerminalId = (int) (w * terminalsPerWarehouse);
 			int upperTerminalId = (int) ((w + 1) * terminalsPerWarehouse);

--- a/src/com/oltpbenchmark/benchmarks/tpcc/TPCCLoader.java
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/TPCCLoader.java
@@ -78,7 +78,7 @@ public class TPCCLoader extends Loader<TPCCBenchmark> {
                 if (!workConf.getEnableForeignKeysAfterLoad() && workConf.getShouldEnableForeignKeys()) {
                     EnableForeignKeyConstraints(conn);
                 }
-                if (workConf.getStartWarehouseId() == 1) {
+                if (workConf.getStartWarehouseIdForShard() == 1) {
                   loadItems(conn, TPCCConfig.configItemCount);
                 }
             }
@@ -88,7 +88,7 @@ public class TPCCLoader extends Loader<TPCCBenchmark> {
         // We use a separate thread per warehouse. Each thread will load
         // all of the tables that depend on that warehouse. They all have
         // to wait until the ITEM table is loaded first though.
-        for (int w = workConf.getStartWarehouseId(); w < workConf.getStartWarehouseId() + numWarehouses; w++) {
+        for (int w = workConf.getStartWarehouseIdForShard(); w < workConf.getStartWarehouseIdForShard() + numWarehouses; w++) {
             final int w_id = w;
             LoaderThread t = new LoaderThread() {
                 @Override

--- a/src/com/oltpbenchmark/benchmarks/tpcc/TPCCWorker.java
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/TPCCWorker.java
@@ -85,7 +85,7 @@ public class TPCCWorker extends Worker<TPCCBenchmark> {
               lowDistrictId = 1;
               highDistrictId = TPCCConfig.configDistPerWhse;
             }
-            proc.run(conn, gen, terminalWarehouseID, wrkld.getTotalWarehousesAcrossExecutions(),
+            proc.run(conn, gen, terminalWarehouseID, wrkld.getTotalWarehousesAcrossShards(),
                     lowDistrictId, highDistrictId, this);
         } catch (ClassCastException ex){
             //fail gracefully

--- a/src/com/oltpbenchmark/benchmarks/tpcc/TPCCWorker.java
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/TPCCWorker.java
@@ -85,7 +85,7 @@ public class TPCCWorker extends Worker<TPCCBenchmark> {
               lowDistrictId = 1;
               highDistrictId = TPCCConfig.configDistPerWhse;
             }
-            proc.run(conn, gen, terminalWarehouseID, numWarehouses,
+            proc.run(conn, gen, terminalWarehouseID, wrkld.getTotalWarehousesAcrossExecutions(),
                     lowDistrictId, highDistrictId, this);
         } catch (ClassCastException ex){
             //fail gracefully

--- a/tpccbenchmark
+++ b/tpccbenchmark
@@ -1,20 +1,3 @@
 #!/bin/bash
 memory='8G'
-arguments=''
-for i; do
-  if [[ "$i" != *"memory"* ]]
-  then
-    arguments="${arguments} ${i}"
-  fi
-done
-
-while [ $# -gt 0 ]; do
-   if [[ $1 == *"--"* ]]; then
-        param="${1/--/}"
-        declare $param="$2"
-   fi
-  shift
-done
-memory="${memory%=}"
-
-java -Xmx$memory -cp `./classpath.sh bin` -Dlog4j.configuration=log4j.properties com.oltpbenchmark.DBWorkload $arguments
+java -Xmx$memory -cp `./classpath.sh bin` -Dlog4j.configuration=log4j.properties com.oltpbenchmark.DBWorkload $@


### PR DESCRIPTION
Summary:
1. Enabled loading with a start warehouse id so as to perform sharded
   loading of TPCC.
2. Enabled execution with a start warehouse id so as to perform sharded
   execution of TPCC.
3. Added a new phase where we enable the foreign keys.

Steps to perform the experiment in the new way:

1. Create the database:
   ./tpccbenchmark --nodes=127.0.0.1 --create=true

2. Run the loading of data in a parallel manner:
   ./tpccbenchmark --nodes=127.0.0.1 --start-warehouse-id=1 --warehouses=10 --load=true
   ./tpccbenchmark --nodes=127.0.0.1 --start-warehouse-id=11 --warehouses=10 --load=true

3. Enable foreign keys after the loading is done:
   ./tpccbenchmark --nodes=127.0.0.1 --enable-foreign-keys=true

4. Execute the runs in a parallel manner:
   ./tpccbenchmark --nodes=127.0.0.1 --start-warehouse-id=1 --warehouses=10 --total-warehouses=20 --execute=true --warmup-time-secs=0   --initial-delay-secs=60
   ./tpccbenchmark --nodes=127.0.0.1 --start-warehouse-id=11 --warehouses=10 --total-warehouses=20 --execute=true --warmup-time-secs=60   --initial-delay-secs=0

The older way of execution still works when we don't want to use the
parallel form of execution.

Reviewers:
Neha, Karthik