### PR TITLE
Reduce client to database calls for New Order inserts and selects

### DIFF
--- a/src/com/oltpbenchmark/api/BenchmarkModule.java
+++ b/src/com/oltpbenchmark/api/BenchmarkModule.java
@@ -129,6 +129,7 @@ public abstract class BenchmarkModule {
             props.setProperty("dataSource.databaseName", workConf.getDBName());
             props.setProperty("maximumPoolSize", Integer.toString(numConnections));
             props.setProperty("connectionTimeout", Integer.toString(workConf.getHikariConnectionTimeout()));
+            props.setProperty("dataSource.reWriteBatchedInserts", "true");
 
             HikariConfig config = new HikariConfig(props);
             listDataSource.add(new HikariDataSource(config));


### PR DESCRIPTION
Summary:
This change involves:
    1. Batching the select for entries in `Item` into 1 statement using the
       'IN' predicate.
    2. Batching the select for entries in `Stock` into 1 statement using the
       'IN' predicate.
    3. Batching the insert for all entries into `OrderLine` using the
       multirow VALUES syntax.

Reviewers:
Karthik, Mihnea