### PR TITLE
 Use SQL procedures for updates to the STOCK table.

### DIFF
--- a/config/workload_all.xml
+++ b/config/workload_all.xml
@@ -17,6 +17,7 @@
     <useThinkTime>true</useThinkTime>
     <enableForeignKeysAfterLoad>true</enableForeignKeysAfterLoad>
     <hikariConnectionTimeoutMs>180000</hikariConnectionTimeoutMs>
+    <useStoredProcedures>true</useStoredProcedures>
    	<transactiontypes>
     	<transactiontype>
     		<name>NewOrder</name>

--- a/src/com/oltpbenchmark/DBWorkload.java
+++ b/src/com/oltpbenchmark/DBWorkload.java
@@ -337,6 +337,10 @@ public class DBWorkload {
         wrkld.setNeedsExecution(true);
       }
 
+      if (xmlConfig.containsKey("useStoredProcedures")) {
+        wrkld.setUseStoredProcedures(xmlConfig.getBoolean("useStoredProcedures"));
+      }
+
       if (!argsLine.hasOption("merge-results")) {
         LOG.info("Configuration -> nodes: " + wrkld.getNodes() +
                  ", port: " + wrkld.getPort() +

--- a/src/com/oltpbenchmark/WorkloadConfiguration.java
+++ b/src/com/oltpbenchmark/WorkloadConfiguration.java
@@ -65,6 +65,7 @@ public class WorkloadConfiguration {
   private int batchSize = 128;
   private int hikariConnectionTimeout = 60000;
   private boolean needsExecution = false;
+  private boolean useStoredProcedures = true;
 
   public TraceReader getTraceReader() {
     return traceReader;
@@ -375,6 +376,11 @@ public class WorkloadConfiguration {
 
   public void setNeedsExecution(boolean needsExecution) { this.needsExecution = needsExecution; }
   public boolean getNeedsExecution() { return this.needsExecution; }
+
+  public void setUseStoredProcedures(boolean useStoredProcedures) {
+    this.useStoredProcedures = useStoredProcedures;
+  }
+  public boolean getUseStoredProcedures() { return this.useStoredProcedures; }
 
   @Override
   public String toString() {


### PR DESCRIPTION
    Summary:
    Currently we batch the updates only when they are part of a SQL
    procedure. Given that we have to perform 10 updates on an average in a
    NewOrder transaction we use the stored procedures to perform these
    updates.

    The stored procedures are created after the Loading of all the tables
    are done.

    The usage of these stored procedures is controlled by the
    'useStoredProcedures' argument in the xml config