### PR TITLE
Add option to create SQL procedures needed by TPCC.

### DIFF
--- a/src/com/oltpbenchmark/DBWorkload.java
+++ b/src/com/oltpbenchmark/DBWorkload.java
@@ -167,6 +167,7 @@ public class DBWorkload {
                       "Total number of warehouses across all executions");
     options.addOption(null, "loaderthreads", true, "Number of loader threads (default 10)");
     options.addOption(null, "enable-foreign-keys", true, "Whether to enable foregin keys");
+    options.addOption(null, "create-sql-procedures", true, "Creates the SQL procedures");
 
     options.addOption(null, "warmup-time-secs", true, "Warmup time in seconds for the benchmark");
     options.addOption(null, "initial-delay-secs", true,
@@ -693,6 +694,12 @@ public class DBWorkload {
     if (isBooleanOptionSet(argsLine, "enable-foreign-keys")) {
       for (BenchmarkModule benchmark : benchList) {
         benchmark.enableForeignKeys();
+      }
+    }
+
+    if (isBooleanOptionSet(argsLine, "create-sql-procedures")) {
+      for (BenchmarkModule benchmark : benchList) {
+        benchmark.createSqlProcedures();
       }
     }
 

--- a/src/com/oltpbenchmark/api/BenchmarkModule.java
+++ b/src/com/oltpbenchmark/api/BenchmarkModule.java
@@ -481,6 +481,8 @@ public abstract class BenchmarkModule {
 
     public abstract void enableForeignKeys() throws Exception;
 
+    public abstract void createSqlProcedures() throws Exception;
+
     /**
      *
      * @param procClass

--- a/src/com/oltpbenchmark/benchmarks/tpcc/TPCCBenchmark.java
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/TPCCBenchmark.java
@@ -162,6 +162,11 @@ public class TPCCBenchmark extends BenchmarkModule {
       loader.EnableForeignKeyConstraints(makeConnection());
     }
 
+    public void createSqlProcedures() throws Exception {
+      TPCCLoader loader = new TPCCLoader(this);
+      loader.CreateSqlProcedures(makeConnection());
+    }
+
     public void test() throws Exception {
       int wId = 1;
       TPCCWorker worker = new TPCCWorker(this, 1 /* worker_id */, 1, 1, 1, 2);


### PR DESCRIPTION
The SQL procedures are generally created automatically after the load. 
If however, there is a case where the cluster doesn't have the procedures (like with backups), 
we can create them using this option.

Summary:
The SQL procedures can be added as follows:
./tpccbenchmark --nodes=<ip> --create-sql-procedures=true

Reviewers:
Mihnea