### PR TITLE
Avoid using join for StockLevel transaction.

### DIFF
--- a/src/com/oltpbenchmark/benchmarks/tpcc/TPCCWorker.java
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/TPCCWorker.java
@@ -105,5 +105,9 @@ public class TPCCWorker extends Worker<TPCCBenchmark> {
     TPCCProcedure proc = (TPCCProcedure) this.getProcedure(
         this.transactionTypes.getType("NewOrder").getProcedureClass());
     proc.test(conn, this);
+
+    proc = (TPCCProcedure) this.getProcedure(
+        this.transactionTypes.getType("StockLevel").getProcedureClass());
+    proc.test(conn, this);
   }
 }

--- a/src/com/oltpbenchmark/benchmarks/tpcc/procedures/StockLevel.java
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/procedures/StockLevel.java
@@ -16,10 +16,13 @@
 
 package com.oltpbenchmark.benchmarks.tpcc.procedures;
 
+import java.lang.Math;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
 import org.apache.log4j.Logger;
@@ -39,7 +42,7 @@ public class StockLevel extends TPCCProcedure {
       " WHERE D_W_ID = ? " +
       "   AND D_ID = ?");
 
-  public SQLStmt stockGetCountStockSQL = new SQLStmt(
+  public SQLStmt stockGetCountUsingJoinSQL = new SQLStmt(
       "SELECT COUNT(DISTINCT (S_I_ID)) AS STOCK_COUNT " +
       " FROM " + TPCCConstants.TABLENAME_ORDERLINE + ", " + TPCCConstants.TABLENAME_STOCK +
       " WHERE OL_W_ID = ?" +
@@ -50,9 +53,36 @@ public class StockLevel extends TPCCProcedure {
       " AND S_I_ID = OL_I_ID" +
       " AND S_QUANTITY < ?");
 
+  public SQLStmt stockGetItemsSQL = new SQLStmt(
+      "SELECT DISTINCT(OL_I_ID) FROM " + TPCCConstants.TABLENAME_ORDERLINE +
+      " WHERE OL_W_ID = ?" +
+      " AND OL_D_ID = ?" +
+      " AND OL_O_ID < ?" +
+      " AND OL_O_ID >= ?");
+
+  public SQLStmt[] stockGetCountSQL;
+
   // Stock Level Txn
   private PreparedStatement stockGetDistOrderId = null;
-  private PreparedStatement stockGetCountStock = null;
+  private PreparedStatement stockGetCountUsingJoin = null;
+  private PreparedStatement stockGetItems = null;
+  private PreparedStatement stockGetCount = null;
+
+  public StockLevel() {
+    // Because we can have as much as 300 (20 orders and a max of 15 items in an order) items in a
+    // single query, we can't have unique statements prepared for all the possible counts. Instead,
+    // we divide a request into a sequence of requests with each request handling (2 ^ i) items.
+    stockGetCountSQL = new SQLStmt[9];
+    StringBuilder sb = new StringBuilder();
+    sb.append(
+      "SELECT COUNT(DISTINCT (S_I_ID)) AS STOCK_COUNT FROM " + TPCCConstants.TABLENAME_STOCK +
+      " WHERE S_W_ID = ? AND S_I_ID in (?");
+    for (int i = 0; i < 9; ++i) {
+      for (int j = 0; i > 0 && j < (1 << (i - 1)); ++j)
+        sb.append(",?");
+      stockGetCountSQL[i] = new SQLStmt(sb.toString() + ") AND S_QUANTITY < ?");
+    }
+  }
 
   public ResultSet run(Connection conn, Random gen,
                         int w_id, int numWarehouses,
@@ -60,14 +90,14 @@ public class StockLevel extends TPCCProcedure {
                         TPCCWorker w) throws SQLException {
     boolean trace = LOG.isTraceEnabled();
     stockGetDistOrderId = this.getPreparedStatement(conn, stockGetDistOrderIdSQL);
-    stockGetCountStock= this.getPreparedStatement(conn, stockGetCountStockSQL);
+    stockGetCountUsingJoin = this.getPreparedStatement(conn, stockGetCountUsingJoinSQL);
+    stockGetItems = this.getPreparedStatement(conn, stockGetItemsSQL);
 
     int threshold = TPCCUtil.randomNumber(10, 20, gen);
     int d_id = TPCCUtil.randomNumber(terminalDistrictLowerID,terminalDistrictUpperID, gen);
 
     int o_id = 0;
     // XXX int i_id = 0;
-    int stock_count = 0;
 
     stockGetDistOrderId.setInt(1, w_id);
     stockGetDistOrderId.setInt(2, d_id);
@@ -82,29 +112,9 @@ public class StockLevel extends TPCCProcedure {
     o_id = rs.getInt("D_NEXT_O_ID");
     rs.close();
 
-    stockGetCountStock.setInt(1, w_id);
-    stockGetCountStock.setInt(2, d_id);
-    stockGetCountStock.setInt(3, o_id);
-    stockGetCountStock.setInt(4, o_id - 20);
-    stockGetCountStock.setInt(5, w_id);
-    stockGetCountStock.setInt(6, threshold);
-    if (trace)
-      LOG.trace(String.format("stockGetCountStock BEGIN [W_ID=%d, D_ID=%d, O_ID=%d]",
-                w_id, d_id, o_id));
-    rs = stockGetCountStock.executeQuery();
-    if (trace) LOG.trace("stockGetCountStock END");
-
-    if (!rs.next()) {
-      String msg = String.format("Failed to get StockLevel result for COUNT query " +
-                                 "[W_ID=%d, D_ID=%d, O_ID=%d]", w_id, d_id, o_id);
-      if (trace) LOG.warn(msg);
-      throw new RuntimeException(msg);
-    }
-    stock_count = rs.getInt("STOCK_COUNT");
-    if (trace) LOG.trace("stockGetCountStock RESULT=" + stock_count);
-
+    List<Integer> itemIds = getItems(w_id, d_id, o_id);
+    int stock_count = getStockCount(w_id, itemIds, threshold, conn);
     conn.commit();
-    rs.close();
 
     if (trace) {
       StringBuilder terminalMessage = new StringBuilder();
@@ -123,5 +133,108 @@ public class StockLevel extends TPCCProcedure {
       LOG.trace(terminalMessage.toString());
     }
     return null;
+  }
+
+  private int getStockCountUsingJoin(int whId, int dId, int oId,
+                                     int threshold) throws SQLException {
+    stockGetCountUsingJoin.setInt(1, whId);
+    stockGetCountUsingJoin.setInt(2, dId);
+    stockGetCountUsingJoin.setInt(3, oId);
+    stockGetCountUsingJoin.setInt(4, oId - 20);
+    stockGetCountUsingJoin.setInt(5, whId);
+    stockGetCountUsingJoin.setInt(6, threshold);
+    ResultSet rs = stockGetCountUsingJoin.executeQuery();
+
+    if (!rs.next()) {
+      String msg = String.format("Failed to get StockLevel result for COUNT query " +
+                                 "[W_ID=%d, D_ID=%d, O_ID=%d]", whId, dId, oId);
+      throw new RuntimeException(msg);
+    }
+    int count = rs.getInt("STOCK_COUNT");
+    rs.close();
+    return count;
+  }
+
+  private List<Integer> getItems(int whId, int dId, int oId) throws SQLException {
+    int k = 1;
+    stockGetItems.setInt(k++, whId);
+    stockGetItems.setInt(k++, dId);
+    stockGetItems.setInt(k++, oId);
+    stockGetItems.setInt(k++, oId - 20);
+    ResultSet rs = stockGetItems.executeQuery();
+
+    List<Integer> out = new ArrayList<Integer>();
+    while (rs.next()) {
+      int item = rs.getInt("OL_I_ID");
+      out.add(item);
+    }
+    rs.close();
+    return out;
+  }
+
+  private int getStockCount(int whId, List<Integer> itemIds, int threshold,
+                            Connection conn) throws SQLException {
+    int stock_count = 0;
+    int len = itemIds.size();
+    int bit = 0;
+    int itemIdx = 0;
+
+    // If number of items is 10 (1010 in binary), then we send 2 requests, one with 2 items and one
+    // with with 8 items.
+    while (len > 0) {
+      if (len % 2 == 0) {
+        len = (len >> 1);
+        ++bit;
+        continue;
+      }
+      int count = (1 << bit);
+      stockGetCount = this.getPreparedStatement(conn, stockGetCountSQL[bit]);
+
+      int k = 1;
+      stockGetCount.setInt(k++, whId);
+      for (int j = 1; j <= count; ++j) {
+        stockGetCount.setInt(k++, itemIds.get(itemIdx++));
+      }
+      stockGetCount.setInt(k++, threshold);
+      ResultSet rs = stockGetCount.executeQuery();
+
+      if (!rs.next()) {
+        String msg = String.format("Failed to get StockLevel result for COUNT query " +
+                                   "[W_ID=%d]", whId);
+        throw new RuntimeException(msg);
+      }
+      stock_count += rs.getInt("STOCK_COUNT");
+      rs.close();
+
+      len = (len >> 1);
+      ++bit;
+    }
+    return stock_count;
+  }
+
+  public void test(Connection conn, TPCCWorker w) throws Exception {
+    stockGetDistOrderId = this.getPreparedStatement(conn, stockGetDistOrderIdSQL);
+    stockGetCountUsingJoin = this.getPreparedStatement(conn, stockGetCountUsingJoinSQL);
+    stockGetItems = this.getPreparedStatement(conn, stockGetItemsSQL);
+
+
+    stockGetDistOrderId.setInt(1, 1);
+    stockGetDistOrderId.setInt(2, 1);
+    ResultSet rs = stockGetDistOrderId.executeQuery();
+    if (!rs.next()) {
+      throw new RuntimeException("Get district order id failed");
+    }
+    int oId = rs.getInt("D_NEXT_O_ID");
+    rs.close();
+
+    int count1 = getStockCountUsingJoin(1, 1, oId, 15);
+
+    List<Integer> items = getItems(1, 1, oId);
+    int count2 = getStockCount(1, items, 15, conn);
+
+    if (count1 != count2) {
+        throw new Exception(
+            String.format("Values not expected for STOCK COUNT %d %d", count1, count2));
+    }
   }
 }


### PR DESCRIPTION
Summary:
StockLevel uses a join across OrderLine and Stock tables to get the
stock of the items present in the last 20 transactions. Performing an
explain on the query showed that we use a NestedLoop across the 2 tables
with the query on the Stock table being a point lookup.

Avoid this expensive reads using the `select in` syntax.

The average latency of the transaction reduces by 40%.
Old Change: Avg Latency: 87.026 msecs, p99 Latency: 463.411 msecs
New Change: Avg Latency: 49.694 msecs, p99 Latency: 570.755 msecs

Reviewers:
Mihnea