### PR TITLE
Display latencies for getting a connection from Hikari pool.

### DIFF
--- a/config/workload_all.xml
+++ b/config/workload_all.xml
@@ -18,6 +18,8 @@
     <enableForeignKeysAfterLoad>true</enableForeignKeysAfterLoad>
     <hikariConnectionTimeoutMs>180000</hikariConnectionTimeoutMs>
     <useStoredProcedures>true</useStoredProcedures>
+    <displayEnhancedLatencyMetrics>false</displayEnhancedLatencyMetrics>
+
    	<transactiontypes>
     	<transactiontype>
     		<name>NewOrder</name>


### PR DESCRIPTION
The new output:
01:39:14,402 (DBWorkload.java:1016) INFO  - Num New Order transactions : 36, time seconds: 180
01:39:14,402 (DBWorkload.java:1017) INFO  - TPM-C: 12
01:39:14,402 (DBWorkload.java:1018) INFO  - Efficiency : 93.31%
01:39:14,403 (DBWorkload.java:1056) INFO  - NewOrder, Avg Latency: 35.67194444444444 msecs, p99 Latency: 172.218 msecs Whole operation, Avg Latency: 56.37466666666666 msecs, p99 Latency: 231.338 msecs
01:39:14,404 (DBWorkload.java:1056) INFO  - Payment, Avg Latency: 25.760722222222224 msecs, p99 Latency: 216.9 msecs Whole operation, Avg Latency: 39.668416666666666 msecs, p99 Latency: 255.616 msecs
01:39:14,404 (DBWorkload.java:1056) INFO  - OrderStatus, Avg Latency: 19.56925 msecs, p99 Latency: 36.103 msecs Whole operation, Avg Latency: 20.107 msecs, p99 Latency: 36.516 msecs
01:39:14,404 (DBWorkload.java:1056) INFO  - Delivery, Avg Latency: 63.89 msecs, p99 Latency: 87.842 msecs Whole operation, Avg Latency: 64.649 msecs, p99 Latency: 88.568 msecs
01:39:14,404 (DBWorkload.java:1056) INFO  - StockLevel, Avg Latency: 135.317 msecs, p99 Latency: 136.352 msecs Whole operation, Avg Latency: 135.9805 msecs, p99 Latency: 136.877 msecs
01:39:14,404 (DBWorkload.java:1068) INFO  - Acquire Connection, Avg Latency: 19.240474999999996 msecs, p99 Latency: 155.616 msecs

Reviewers:
Mihnea, Rob