### PR TITLE
Remove `for update` from select queries in NewOrder transaction.

### DIFF
--- a/src/com/oltpbenchmark/benchmarks/tpcc/procedures/NewOrder.java
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/procedures/NewOrder.java
@@ -56,7 +56,7 @@ public class NewOrder extends TPCCProcedure {
   public final SQLStmt stmtGetDistSQL = new SQLStmt(
       "SELECT D_NEXT_O_ID, D_TAX " +
       "  FROM " + TPCCConstants.TABLENAME_DISTRICT +
-      " WHERE D_W_ID = ? AND D_ID = ? FOR UPDATE");
+      " WHERE D_W_ID = ? AND D_ID = ?");
 
   public final SQLStmt  stmtInsertNewOrderSQL = new SQLStmt(
       "INSERT INTO " + TPCCConstants.TABLENAME_NEWORDER +
@@ -79,7 +79,7 @@ public class NewOrder extends TPCCProcedure {
       "       S_DIST_06, S_DIST_07, S_DIST_08, S_DIST_09, S_DIST_10" +
       "  FROM " + TPCCConstants.TABLENAME_STOCK +
       " WHERE S_I_ID = ? " +
-      "   AND S_W_ID = ? FOR UPDATE");
+      "   AND S_W_ID = ?");
 
   public final SQLStmt  stmtInsertOOrderSQL = new SQLStmt(
       "INSERT INTO " + TPCCConstants.TABLENAME_OPENORDER +


### PR DESCRIPTION
Summary:
The NewOrder transaction performs a select on the District and the Stock
table with a row level lock. This row level lock is unnecessary as we
are following this up with a write to the same rows.

Reviewers:
Mihnea