### PR TITLE
added support for jdbcURL parameter

### DIFF
--- a/config/workload_all.xml
+++ b/config/workload_all.xml
@@ -10,6 +10,7 @@
 
     <sslCert></sslCert>
     <sslKey></sslKey>
+    <jdbcURL></jdbcURL>
 
     <!--
     <terminals>100</terminals>

--- a/src/com/oltpbenchmark/DBWorkload.java
+++ b/src/com/oltpbenchmark/DBWorkload.java
@@ -284,6 +284,10 @@ public class DBWorkload {
         wrkld.setSslKey(xmlConfig.getString("sslKey"));
       }
 
+      if (xmlConfig.containsKey("jdbcURL") && xmlConfig.getString("jdbcURL").length() > 0) {
+        wrkld.setJdbcURL(xmlConfig.getString("jdbcURL"));
+      }
+
       int terminals = xmlConfig.getInt("terminals[not(@bench)]", numWarehouses * 10);
       terminals = xmlConfig.getInt("terminals" + pluginTest, terminals);
       wrkld.setTerminals(terminals);

--- a/src/com/oltpbenchmark/WorkloadConfiguration.java
+++ b/src/com/oltpbenchmark/WorkloadConfiguration.java
@@ -48,8 +48,9 @@ public class WorkloadConfiguration {
   private String db_username;
   private String db_password;
   private String db_driver;
-  private String sslCert = "";
-  private String sslKey = "";
+  private String sslCert;
+  private String sslKey;
+  private String jdbcURL;
   private int numWarehouses = -1;
   private int startWarehouseIdForShard = -1;
   private int totalWarehousesAcrossShards = -1;
@@ -202,6 +203,14 @@ public class WorkloadConfiguration {
 
   public String getSslKey() {
     return this.sslKey;
+  }
+
+  public String getJdbcURL() {
+    return jdbcURL;
+  }
+
+  public void setJdbcURL(String jdbcURL) {
+    this.jdbcURL = jdbcURL;
   }
 
 

--- a/src/com/oltpbenchmark/api/BenchmarkModule.java
+++ b/src/com/oltpbenchmark/api/BenchmarkModule.java
@@ -136,8 +136,10 @@ public abstract class BenchmarkModule {
               props.put("dataSource.sslcert", workConf.getSslCert());
               props.put("dataSource.sslkey", workConf.getSslKey());
             }
-
             HikariConfig config = new HikariConfig(props);
+            if (workConf.getJdbcURL().length()>0) {
+              config.setJdbcUrl(workConf.getJdbcURL());
+            }
             listDataSource.add(new HikariDataSource(config));
         }
     }
@@ -155,11 +157,15 @@ public abstract class BenchmarkModule {
         }
 
         int r = dataSourceCounter.getAndIncrement() % workConf.getNodes().size();
-
-        String connectStr = String.format("jdbc:postgresql://%s:%d/%s",
-                                          workConf.getNodes().get(r),
-                                          workConf.getPort(),
-                                          workConf.getDBName());
+        String connectStr = null;
+        if (workConf.getJdbcURL().length()>0) {
+            connectStr=workConf.getJdbcURL();
+        } else {
+            connectStr = String.format("jdbc:postgresql://%s:%d/%s",
+                workConf.getNodes().get(r),
+                workConf.getPort(),
+                workConf.getDBName());
+        }
         return DriverManager.getConnection(connectStr, props);
     }
 


### PR DESCRIPTION
Summary:
Enabling support for the full jdbcURL to be specified in the config file.
This unlock the full potential of whichever driver is being used.
The jdbc URL can be specified this way:
```xml
<jdbcURL>jdbc:postgresql://localhost/test?user=fred&password=secret&ssl=true</jdbcURL>
```
When a parameter is passed both on the URL and as config property, the latter will take precedence.
    
Reviewers:
psudheer21