### PR TITLE
Ensure that SSL cert and keys are initialized with an empty string.

### DIFF
--- a/src/com/oltpbenchmark/WorkloadConfiguration.java
+++ b/src/com/oltpbenchmark/WorkloadConfiguration.java
@@ -48,8 +48,8 @@ public class WorkloadConfiguration {
   private String db_username;
   private String db_password;
   private String db_driver;
-  private String sslCert;
-  private String sslKey;
+  private String sslCert = "";
+  private String sslKey = "";
   private int numWarehouses = -1;
   private int startWarehouseIdForShard = -1;
   private int totalWarehousesAcrossShards = -1;


### PR DESCRIPTION
Summary:
The check for the presence of the SSL keys and certs is done by checking
the length of the string. But the variables were not initialized with
empty strings. This caused Null Pointed exceptions. This change fixes
the same.

Reviewers:
Rob, Mihnea