### PR TITLE
Retry transaction failures.

### DIFF
--- a/config/workload_all.xml
+++ b/config/workload_all.xml
@@ -49,5 +49,6 @@
           <weights>45,43,4,4,4</weights>
         </work>
 	</works>
-		
+    <maxRetriesPerTransaction>2</maxRetriesPerTransaction>
+
 </parameters>

--- a/src/com/oltpbenchmark/DBWorkload.java
+++ b/src/com/oltpbenchmark/DBWorkload.java
@@ -323,6 +323,10 @@ public class DBWorkload {
         wrkld.setBatchSize(xmlConfig.getInt("batchSize"));
       }
 
+      if (xmlConfig.containsKey("maxRetriesPerTransaction")) {
+        wrkld.setMaxRetriesPerTransaction(xmlConfig.getInt("maxRetriesPerTransaction"));
+      }
+
       if (xmlConfig.containsKey("port")) {
         wrkld.setPort(xmlConfig.getInt("port"));
       }
@@ -1034,6 +1038,12 @@ public class DBWorkload {
       xmlConfig.containsKey("displayEnhancedLatencyMetrics") &&
       xmlConfig.getBoolean("displayEnhancedLatencyMetrics");
     PrintLatencies(workers, displayEnhancedLatencyMetrics);
+
+    int total_retries = 0;
+    for (Worker<?> w : workers) {
+      total_retries += w.getTotalRetries();
+    }
+    LOG.info("Total retries : " + total_retries);
 
     return r;
   }

--- a/src/com/oltpbenchmark/WorkloadConfiguration.java
+++ b/src/com/oltpbenchmark/WorkloadConfiguration.java
@@ -70,6 +70,7 @@ public class WorkloadConfiguration {
   private int hikariConnectionTimeout = 60000;
   private boolean needsExecution = false;
   private boolean useStoredProcedures = true;
+  private int maxRetriesPerTransaction = 0;
 
   public TraceReader getTraceReader() {
     return traceReader;
@@ -418,6 +419,14 @@ public class WorkloadConfiguration {
     this.useStoredProcedures = useStoredProcedures;
   }
   public boolean getUseStoredProcedures() { return this.useStoredProcedures; }
+
+  public void setMaxRetriesPerTransaction(int maxRetriesPerTransaction) {
+    this.maxRetriesPerTransaction = maxRetriesPerTransaction;
+  }
+
+  public int getMaxRetriesPerTransaction() {
+    return maxRetriesPerTransaction;
+  }
 
   @Override
   public String toString() {


### PR DESCRIPTION
Currently the failed transactions are not retried and are being
recognized as successes. Make sure that the transaction failures are
retried properly. Also make sure that the failures are not added to the
results.

Reviewers:
Mihnea, Rob