### PR TITLE
Display retry and failed metrics per transaction.

### DIFF
--- a/config/workload_all.xml
+++ b/config/workload_all.xml
@@ -49,6 +49,10 @@
           <weights>45,43,4,4,4</weights>
         </work>
 	</works>
-    <maxRetriesPerTransaction>2</maxRetriesPerTransaction>
+    <!--
+      Set the number of retries to 0 as retrying when the number of warehouses is
+      high is pointless as it just leads to more failures.
+    -->
+    <maxRetriesPerTransaction>0</maxRetriesPerTransaction>
 
 </parameters>

--- a/src/com/oltpbenchmark/DBWorkload.java
+++ b/src/com/oltpbenchmark/DBWorkload.java
@@ -1039,12 +1039,17 @@ public class DBWorkload {
       xmlConfig.getBoolean("displayEnhancedLatencyMetrics");
     PrintLatencies(workers, displayEnhancedLatencyMetrics);
 
-    int total_retries = 0;
+    int numTxnTypes = workConfs.get(0).getNumTxnTypes();
+    int[] totalRetries = new int[numTxnTypes];
+    int[] totalFailures = new int[numTxnTypes];
     for (Worker<?> w : workers) {
-      total_retries += w.getTotalRetries();
+      for (int i = 0; i < numTxnTypes; ++i) {
+        totalRetries[i] += w.getTotalRetries()[i];
+        totalFailures[i] += w.getTotalFailures()[i];
+      }
     }
-    LOG.info("Total retries : " + total_retries);
-
+    LOG.info(String.format("Total retries: %s Total failures: %s",
+                           Arrays.toString(totalRetries), Arrays.toString(totalFailures)));
     return r;
   }
 


### PR DESCRIPTION
The retried and failed metrics will look as follows:
Total retries : [24966, 10590, 0, 1231, 1043] Total Failures: [16971, 1857, 122, 496, 130]

This change also sets the number of retries to 0 since retries are not
helping when the number of WH is large. It is better to count them as
failures and save on CPU.

Reviewers:
Rob