### PR TITLE
Fix Invalid Procedure instance to be instantiate-able

### DIFF
--- a/src/com/oltpbenchmark/api/TransactionType.java
+++ b/src/com/oltpbenchmark/api/TransactionType.java
@@ -16,9 +16,21 @@
 
 package com.oltpbenchmark.api;
 
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+
 public class TransactionType implements Comparable<TransactionType> {
 
-    public abstract static class Invalid extends Procedure { }
+    public static class Invalid extends Procedure {
+		@Override
+		public ResultSet run(
+				Connection conn, Random gen, int terminalWarehouseID, int numWarehouses, int terminalDistrictLowerID,
+				int terminalDistrictUpperID, Worker w) throws SQLException {
+			return null;
+		}
+	}
     public static final int INVALID_ID = 0;
     public static final TransactionType INVALID = new TransactionType(Invalid.class, INVALID_ID);
     


### PR DESCRIPTION
In https://github.com/yugabyte/tpcc/pull/80, we removed TPCCProcedure, and the `Invalid` stub class was changed to abstract since it no longer implemented all abstract methods in the base class. This meant it could not be instantiated during the execute phase of TPCC. For some reason, we instantiate an instance of this class during the execute phase no matter what. Without this change, an exception is thrown during instantiation, though it otherwise runs fine.