### PR TITLE
Enhance the output of TPCC execution results

### DIFF
--- a/src/com/oltpbenchmark/benchmarks/tpcc/procedures/NewOrder.java
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/procedures/NewOrder.java
@@ -243,6 +243,8 @@ public class NewOrder extends Procedure {
     }
 
     // we need to cause 1% of the new orders to be rolled back.
+    // TODO -- in this case, lets make sure our retry/failure bookkeeping is smart enough to distinguish between this
+    // vs. unexpected failures.
     if (TPCCUtil.randomNumber(1, 100, gen) == 1)
       itemIDs[numItems - 1] = TPCCConfig.INVALID_ITEM_ID;
 


### PR DESCRIPTION
This PR makes a few changes:
1. Track "pipeline" of retry/failure for each Procedure type
2. Display percentage failure
3. Tabulate the format of the output data

Sample output:
```
23:56:04,861 (DBWorkload.java:949) INFO  -
================RESULTS================
             TPM-C |           24878.30
        Efficiency |             96.73%
Throughput (req/s) |             933.67

23:56:05,433 (DBWorkload.java:976) INFO  -
================LATENCIES===============
 Operation  | Avg. Latency | P99 Latency
   NewOrder |        68.44 |      408.00
    Payment |        41.20 |      218.12
OrderStatus |        22.78 |      167.98
   Delivery |       194.94 |     1255.64
 StockLevel |       106.25 |      392.52

23:56:05,445 (DBWorkload.java:1022) INFO  -
====================RETRIES===================
   Operation   | Total Created | Retry Number 1 | Retry Number 2 |     Failures
      NewOrder |        762023 | 13077 ( 1.72%) |  4432 ( 0.58%) |  8888 ( 1.17%)
       Payment |        736313 | 11215 ( 1.52%) |  6625 ( 0.90%) |  3686 ( 0.50%)
   OrderStatus |         68687 |     0 ( 0.00%) |     0 ( 0.00%) |     0 ( 0.00%)
      Delivery |         68683 |   396 ( 0.58%) |   272 ( 0.40%) |   200 ( 0.29%)
    StockLevel |         68291 |     0 ( 0.00%) |     0 ( 0.00%) |     0 ( 0.00%)

```