### PR TITLE
Pull command line and config file option readers into separate components

### DIFF
--- a/config/workload_all.xml
+++ b/config/workload_all.xml
@@ -12,10 +12,6 @@
     <sslKey></sslKey>
     <jdbcURL></jdbcURL>
 
-    <!--
-    <terminals>100</terminals>
-    -->
-
     <batchSize>128</batchSize>
     <useKeyingTime>true</useKeyingTime>
     <useThinkTime>true</useThinkTime>
@@ -26,30 +22,30 @@
     <trackPerSQLStmtLatencies>false</trackPerSQLStmtLatencies>
 
    	<transactiontypes>
-    	<transactiontype>
-    		<name>NewOrder</name>
-    	</transactiontype>
-    	<transactiontype>
-    		<name>Payment</name>
-    	</transactiontype>
-    	<transactiontype>
-    		<name>OrderStatus</name>
-    	</transactiontype>
-    	<transactiontype>
-    		<name>Delivery</name>
-    	</transactiontype>
-    	<transactiontype>
-    		<name>StockLevel</name>
-    	</transactiontype>
+        <transaction>
+            <name>NewOrder</name>
+            <weight>45</weight>
+        </transaction>
+        <transaction>
+            <name>Payment</name>
+            <weight>43</weight>
+        </transaction>
+        <transaction>
+            <name>OrderStatus</name>
+            <weight>4</weight>
+        </transaction>
+        <transaction>
+            <name>Delivery</name>
+            <weight>4</weight>
+        </transaction>
+        <transaction>
+            <name>StockLevel</name>
+            <weight>4</weight>
+        </transaction>
    	</transactiontypes>
-    <works>
-        <work>
-          <time>1800</time>
-          <rate>10000</rate>
-          <ratelimited bench="tpcc">true</ratelimited>
-          <weights>45,43,4,4,4</weights>
-        </work>
-	</works>
+
+    <runtime>1800</runtime>
+    <rate>10000</rate>
     <!--
       Set the number of retries to 0 as retrying when the number of warehouses is
       high is pointless as it just leads to more failures.

--- a/src/com/oltpbenchmark/CommandLineOptions.java
+++ b/src/com/oltpbenchmark/CommandLineOptions.java
@@ -1,0 +1,183 @@
+package com.oltpbenchmark;
+
+import org.apache.commons.cli.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+public class CommandLineOptions {
+    private CommandLine argsLine;
+
+    private static Options COMMAND_LINE_OPTS = new Options();
+    static {
+        COMMAND_LINE_OPTS.addOption("h", "help", false, "Print this help");
+        COMMAND_LINE_OPTS.addOption(
+                null,
+                "create",
+                true,
+                "Initialize the database for this benchmark");
+        COMMAND_LINE_OPTS.addOption(
+                null,
+                "clear",
+                true,
+                "Clear all records in the database for this benchmark");
+        COMMAND_LINE_OPTS.addOption(
+                null,
+                "load",
+                true,
+                "Load data using the benchmark's data loader");
+        COMMAND_LINE_OPTS.addOption(
+                null,
+                "execute",
+                true,
+                "Execute the benchmark workload");
+
+
+        COMMAND_LINE_OPTS.addOption(
+                "c",
+                "config",
+                true,
+                "Workload configuration file [default: config/workload_all.xml]");
+
+        COMMAND_LINE_OPTS.addOption("v", "verbose", false, "Display Messages");
+        COMMAND_LINE_OPTS.addOption("s", "sample", true, "Sampling window");
+        COMMAND_LINE_OPTS.addOption("im", "interval-monitor", true,
+                "Throughput Monitoring Interval in milliseconds");
+        COMMAND_LINE_OPTS.addOption("ss", false, "Verbose Sampling per Transaction");
+        COMMAND_LINE_OPTS.addOption("ts", "tracescript", true, "Script of transactions to execute");
+        COMMAND_LINE_OPTS.addOption(null, "histograms", false, "Print txn histograms");
+        COMMAND_LINE_OPTS.addOption(null, "output-raw", true, "Output raw data");
+        COMMAND_LINE_OPTS.addOption(null, "output-samples", true, "Output sample data");
+
+        COMMAND_LINE_OPTS.addOption(null, "nodes", true, "comma separated list of nodes (default 127.0.0.1)");
+        COMMAND_LINE_OPTS.addOption(null, "warehouses", true, "Number of warehouses (default 10)");
+        COMMAND_LINE_OPTS.addOption(null, "start-warehouse-id", true, "Start warehouse id");
+        COMMAND_LINE_OPTS.addOption(null, "total-warehouses", true,
+                "Total number of warehouses across all executions");
+        COMMAND_LINE_OPTS.addOption(null, "loaderthreads", true, "Number of loader threads (default 10)");
+        COMMAND_LINE_OPTS.addOption(null, "enable-foreign-keys", true, "Whether to enable foregin keys");
+        COMMAND_LINE_OPTS.addOption(null, "create-sql-procedures", true, "Creates the SQL procedures");
+
+        COMMAND_LINE_OPTS.addOption(null, "warmup-time-secs", true, "Warmup time in seconds for the benchmark");
+        COMMAND_LINE_OPTS.addOption(null, "initial-delay-secs", true,
+                "Delay in seconds for starting the benchmark");
+        COMMAND_LINE_OPTS.addOption(null, "num-connections", true, "Number of connections used");
+
+
+        COMMAND_LINE_OPTS.addOption(null, "merge-results", true, "Merge results from various output files");
+        COMMAND_LINE_OPTS.addOption(null, "dir", true, "Directory containing the csv files");
+    }
+
+    public CommandLineOptions() {}
+
+    public static enum Mode {
+        HELP,
+        CREATE,
+        CLEAR,
+        LOAD,
+        EXECUTE,
+        MERGE_RESULTS
+    }
+
+    void init(String[] args) throws ParseException {
+        CommandLineParser parser = new PosixParser();
+        argsLine = parser.parse(COMMAND_LINE_OPTS, args);
+    }
+
+    private boolean isBooleanOptionSet(String key) {
+        if (argsLine.hasOption(key)) {
+            String val = argsLine.getOptionValue(key);
+            return val != null && val.equalsIgnoreCase("true");
+        }
+        return false;
+    }
+
+    public Mode getMode() {
+        if (argsLine.hasOption("h")) return Mode.HELP;
+        if (isBooleanOptionSet("clear")) return Mode.CLEAR;
+        if (isBooleanOptionSet("create")) return Mode.CREATE;
+        if (isBooleanOptionSet("load")) return Mode.LOAD;
+        if (isBooleanOptionSet("execute")) return Mode.EXECUTE;
+        assert isBooleanOptionSet("merge-results");
+        return Mode.MERGE_RESULTS;
+    }
+
+    public void printHelp() {
+        HelpFormatter hlpfrmt = new HelpFormatter();
+        hlpfrmt.printHelp("tpccbenchmark", COMMAND_LINE_OPTS);
+    }
+
+    public Optional<String> getStringOpt(String key) {
+        if (argsLine.hasOption(key)) {
+            return Optional.of(argsLine.getOptionValue(key));
+        }
+        return Optional.empty();
+    }
+
+    public Optional<String> getConfigFile() {
+        return getStringOpt("c");
+    }
+
+    private Optional<Integer> getIntOpt(String key) {
+        if (argsLine.hasOption(key)) {
+            return Optional.of(Integer.parseInt(argsLine.getOptionValue(key)));
+        }
+        return Optional.empty();
+    }
+
+    public Optional<Integer> getIntervalMonitor() {
+        return getIntOpt("im");
+    }
+
+    public Optional<List<String>> getNodes() {
+        if (argsLine.hasOption("nodes")) {
+            return Optional.of(Arrays.asList(argsLine.getOptionValue("nodes").split(",")));
+        }
+        return Optional.empty();
+    }
+
+    public Optional<Integer> getWarehouses() {
+        return getIntOpt("warehouses");
+    }
+
+    public Optional<Integer> getStartWarehouseId() {
+        return getIntOpt("start-warehouse-id");
+    }
+
+    public Optional<Integer> getTotalWarehouses() {
+        return getIntOpt("total-warehouses");
+    }
+
+    public Optional<Integer> getLoaderThreads() {
+        return getIntOpt("loaderthreads");
+    }
+
+    public Optional<Integer> getNumDbConnections() {
+        return getIntOpt("num-connections");
+    }
+
+    public Optional<Integer> getWarmupTime() {
+        return getIntOpt("num-connections");
+    }
+
+    public Optional<Integer> getInitialDelaySeconds() {
+        return getIntOpt("initial-delay-secs");
+    }
+
+    public boolean getIsEnableForeignKeysSet() {
+        return isBooleanOptionSet("enable-foreign-keys");
+    }
+
+    public boolean getIsCreateSqlProceduresSet() {
+        return isBooleanOptionSet("create-sql-procedures");
+    }
+
+    public Optional<String> getDirPath() {
+        return getStringOpt("dir");
+    }
+
+    public boolean getIsOutputMetricHistogramsSet() {
+        return isBooleanOptionSet("histograms");
+    }
+}

--- a/src/com/oltpbenchmark/CommandLineOptions.java
+++ b/src/com/oltpbenchmark/CommandLineOptions.java
@@ -40,16 +40,11 @@ public class CommandLineOptions {
                 true,
                 "Workload configuration file [default: config/workload_all.xml]");
 
-        COMMAND_LINE_OPTS.addOption("v", "verbose", false, "Display Messages");
-        COMMAND_LINE_OPTS.addOption("s", "sample", true, "Sampling window");
         COMMAND_LINE_OPTS.addOption("im", "interval-monitor", true,
                 "Throughput Monitoring Interval in milliseconds");
-        COMMAND_LINE_OPTS.addOption("ss", false, "Verbose Sampling per Transaction");
-        COMMAND_LINE_OPTS.addOption("ts", "tracescript", true, "Script of transactions to execute");
         COMMAND_LINE_OPTS.addOption(null, "histograms", false, "Print txn histograms");
         COMMAND_LINE_OPTS.addOption(null, "output-raw", true, "Output raw data");
         COMMAND_LINE_OPTS.addOption(null, "output-samples", true, "Output sample data");
-
         COMMAND_LINE_OPTS.addOption(null, "nodes", true, "comma separated list of nodes (default 127.0.0.1)");
         COMMAND_LINE_OPTS.addOption(null, "warehouses", true, "Number of warehouses (default 10)");
         COMMAND_LINE_OPTS.addOption(null, "start-warehouse-id", true, "Start warehouse id");
@@ -58,20 +53,17 @@ public class CommandLineOptions {
         COMMAND_LINE_OPTS.addOption(null, "loaderthreads", true, "Number of loader threads (default 10)");
         COMMAND_LINE_OPTS.addOption(null, "enable-foreign-keys", true, "Whether to enable foregin keys");
         COMMAND_LINE_OPTS.addOption(null, "create-sql-procedures", true, "Creates the SQL procedures");
-
         COMMAND_LINE_OPTS.addOption(null, "warmup-time-secs", true, "Warmup time in seconds for the benchmark");
         COMMAND_LINE_OPTS.addOption(null, "initial-delay-secs", true,
                 "Delay in seconds for starting the benchmark");
         COMMAND_LINE_OPTS.addOption(null, "num-connections", true, "Number of connections used");
-
-
         COMMAND_LINE_OPTS.addOption(null, "merge-results", true, "Merge results from various output files");
         COMMAND_LINE_OPTS.addOption(null, "dir", true, "Directory containing the csv files");
     }
 
     public CommandLineOptions() {}
 
-    public static enum Mode {
+    public enum Mode {
         HELP,
         CREATE,
         CLEAR,

--- a/src/com/oltpbenchmark/ConfigFileOptions.java
+++ b/src/com/oltpbenchmark/ConfigFileOptions.java
@@ -1,0 +1,135 @@
+package com.oltpbenchmark;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.XMLConfiguration;
+import org.apache.commons.configuration.tree.xpath.XPathExpressionEngine;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class ConfigFileOptions {
+    XMLConfiguration xmlConfig;
+
+    ConfigFileOptions(String filePath) throws ConfigurationException {
+        xmlConfig = new XMLConfiguration(filePath);
+        xmlConfig.setExpressionEngine(new XPathExpressionEngine());
+    }
+
+    public String getDbDriver() {
+        return xmlConfig.getString("driver");
+    }
+
+    public String getDbName() {
+        return xmlConfig.getString("DBName");
+    }
+
+    public String getDbUsername() {
+        return xmlConfig.getString("username");
+    }
+
+    public String getDbPassword() {
+        return xmlConfig.getString("password");
+    }
+
+    private Optional<String> getStringOpt(String key) {
+        if (xmlConfig.containsKey(key) && xmlConfig.getString(key).length() > 0) {
+            return Optional.of(xmlConfig.getString(key));
+        }
+        return Optional.empty();
+    }
+
+    public Optional<String> getSslCert() {
+        return getStringOpt("sslCert");
+    }
+
+    public Optional<String> getSslKey() {
+        return getStringOpt("sslKey");
+    }
+
+    public Optional<String> getJdbcUrl() {
+        return getStringOpt("jdbcURL");
+    }
+
+    public Optional<String> getIsolationLevel() {
+        return getStringOpt("isolation");
+    }
+
+    private Optional<Boolean> getBoolOpt(String key) {
+        if (xmlConfig.containsKey(key)) {
+            return Optional.of(xmlConfig.getBoolean(key));
+        }
+        return Optional.empty();
+    }
+
+    public Optional<Boolean> getUseKeyingTime() {
+        return getBoolOpt("useKeyingTime");
+    }
+
+    public Optional<Boolean> getUseThinkTime() {
+        return getBoolOpt("useThinkTime");
+    }
+
+    public Optional<Boolean> getEnableForeignKeysAfterLoad() {
+        return getBoolOpt("enableForeignKeysAfterLoad");
+    }
+
+    public Optional<Boolean> getTrackPerSQLStmtLatencies() {
+        return getBoolOpt("trackPerSQLStmtLatencies");
+    }
+
+    public Optional<Boolean> getUseStoredProcedures() {
+        return getBoolOpt("useStoredProcedures");
+    }
+
+    private Optional<Integer> getIntOpt(String key) {
+        if (xmlConfig.containsKey(key)) {
+            return Optional.of(xmlConfig.getInt(key));
+        }
+        return Optional.empty();
+    }
+
+    public Optional<Integer> getBatchSize() {
+        return getIntOpt("batchSize");
+    }
+
+    public Optional<Integer> getMaxRetriesPerTransaction() {
+        return getIntOpt("maxRetriesPerTransaction");
+    }
+
+    public Optional<Integer> getMaxLoaderRetries() {
+        return getIntOpt("maxLoaderRetries");
+    }
+
+    public Optional<Integer> getPort() {
+        return getIntOpt("port");
+    }
+
+    public Optional<Integer> getHikariConnectionTimeoutMs() {
+        return getIntOpt("hikariConnectionTimeoutMs");
+    }
+
+    public int getTransactionTypeCount() {
+        return xmlConfig.getList("transactiontypes/transaction/name").size();
+    }
+
+    public Optional<String> getTransactionTypeName(int idx) {
+        return getStringOpt(String.format("transactiontypes/transaction[%d]/name", idx));
+    }
+
+    public Optional<String> getTransactionTypeWeight(int idx) {
+        return getStringOpt(String.format("transactiontypes/transaction[%d]/weight", idx));
+    }
+
+    public Optional<Integer> getRate() {
+        return getIntOpt("rate");
+    }
+
+    public Optional<Integer> getRuntime() {
+        return getIntOpt("runtime");
+    }
+
+    public Optional<String> getWeightsString() {
+        return getStringOpt("weights");
+    }
+}

--- a/src/com/oltpbenchmark/DBWorkload.java
+++ b/src/com/oltpbenchmark/DBWorkload.java
@@ -18,15 +18,10 @@
 package com.oltpbenchmark;
 
 import java.io.*;
-import java.sql.Timestamp;
 import java.text.DecimalFormat;
 import java.util.*;
+import java.util.stream.Collectors;
 
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.PosixParser;
 import org.apache.commons.collections15.map.ListOrderedMap;
 import org.apache.commons.configuration.SubnodeConfiguration;
 import org.apache.commons.configuration.XMLConfiguration;
@@ -88,88 +83,8 @@ public class DBWorkload {
       LOG.warn("\n" + getAssertWarning());
     }
 
-    // create the command line parser
-    CommandLineParser parser = new PosixParser();
-    Options options = new Options();
-    options.addOption(
-            "c",
-            "config",
-            true,
-            "Workload configuration file [default: config/workload_all.xml]");
-    options.addOption(
-            null,
-            "create",
-            true,
-            "Initialize the database for this benchmark");
-    options.addOption(
-            null,
-            "clear",
-            true,
-            "Clear all records in the database for this benchmark");
-    options.addOption(
-            null,
-            "load",
-            true,
-            "Load data using the benchmark's data loader");
-    options.addOption(
-            null,
-            "execute",
-            true,
-            "Execute the benchmark workload");
-    options.addOption(
-            null,
-            "test",
-            true,
-            "Test the benchmark procedure execution");
-    options.addOption(
-            null,
-            "runscript",
-            true,
-            "Run an SQL script");
-    options.addOption(
-            null,
-            "upload",
-            true,
-            "Upload the result");
-    options.addOption(
-            null,
-            "uploadHash",
-            true,
-            "git hash to be associated with the upload");
-
-    options.addOption("v", "verbose", false, "Display Messages");
-    options.addOption("h", "help", false, "Print this help");
-    options.addOption("s", "sample", true, "Sampling window");
-    options.addOption("im", "interval-monitor", true,
-                      "Throughput Monitoring Interval in milliseconds");
-    options.addOption("ss", false, "Verbose Sampling per Transaction");
-    options.addOption("o", "output", true, "Output file (default System.out)");
-    options.addOption("d", "directory", true,
-                      "Base directory for the result files, default is current directory");
-    options.addOption("t", "timestamp", false,
-                      "Result file is prepended with timestamp for the beginning of the experiment");
-    options.addOption("ts", "tracescript", true, "Script of transactions to execute");
-    options.addOption(null, "histograms", false, "Print txn histograms");
-    options.addOption(null, "output-raw", true, "Output raw data");
-    options.addOption(null, "output-samples", true, "Output sample data");
-
-    options.addOption(null, "nodes", true, "comma separated list of nodes (default 127.0.0.1)");
-    options.addOption(null, "warehouses", true, "Number of warehouses (default 10)");
-    options.addOption(null, "start-warehouse-id", true, "Start warehouse id");
-    options.addOption(null, "total-warehouses", true,
-                      "Total number of warehouses across all executions");
-    options.addOption(null, "loaderthreads", true, "Number of loader threads (default 10)");
-    options.addOption(null, "enable-foreign-keys", true, "Whether to enable foregin keys");
-    options.addOption(null, "create-sql-procedures", true, "Creates the SQL procedures");
-
-    options.addOption(null, "warmup-time-secs", true, "Warmup time in seconds for the benchmark");
-    options.addOption(null, "initial-delay-secs", true,
-                      "Delay in seconds for starting the benchmark");
-    options.addOption(null, "num-connections", true, "Number of connections used");
-
-
-    options.addOption(null, "merge-results", true, "Merge results from various output files");
-    options.addOption(null, "dir", true, "Directory containing the csv files");
+    CommandLineOptions options = new CommandLineOptions();
+    options.init(args);
 
     transactionTypes.put(1, "NewOrder");
     transactionTypes.put(2, "Payment");
@@ -177,49 +92,32 @@ public class DBWorkload {
     transactionTypes.put(4, "Delivery");
     transactionTypes.put(5, "StockLevel");
 
+    if (options.getMode() == CommandLineOptions.Mode.HELP) {
+      options.printHelp();
+      return;
+    }
 
-    // parse the command line arguments
-    CommandLine argsLine = parser.parse(options, args);
-    if (argsLine.hasOption("h")) {
-      printUsage(options);
+    if (options.getMode() == CommandLineOptions.Mode.MERGE_RESULTS) {
+      String dirPath = options.getDirPath().orElseThrow(() ->
+              new RuntimeException("Must specify directory with results to merge with --dir={directory path}"));
+      File dir = new File(dirPath);
+      String[] files = dir.list();
+      mergeResults(dirPath, files);
       return;
     }
 
     // Seconds
-    int intervalMonitor = 0;
-    if (argsLine.hasOption("im")) {
-      intervalMonitor = Integer.parseInt(argsLine.getOptionValue("im"));
-    }
+    int intervalMonitor = options.getIntervalMonitor().orElse(0);
 
-    String val = argsLine.getOptionValue("nodes");
+    List<String> nodes = options.getNodes().orElse(Arrays.asList("127.0.0.1"));
 
-    List<String> nodes = new ArrayList<>();
-    nodes.add("127.0.0.1");
+    numWarehouses = options.getWarehouses().orElse(numWarehouses);
 
-    if (argsLine.hasOption("nodes")) {
-      nodes = Arrays.asList(val.split(","));
-    }
+    startWarehouseIdForShard = options.getStartWarehouseId().orElse(1);
 
-    if (argsLine.hasOption("warehouses")) {
-      numWarehouses = Integer.parseInt(argsLine.getOptionValue("warehouses"));
-    }
+    totalWarehousesAcrossShards = options.getTotalWarehouses().orElse(numWarehouses);
 
-    if (argsLine.hasOption("start-warehouse-id")) {
-      startWarehouseIdForShard = Integer.parseInt(argsLine.getOptionValue("start-warehouse-id"));
-    } else {
-      startWarehouseIdForShard = 1;
-    }
-
-    if (argsLine.hasOption("total-warehouses")) {
-      totalWarehousesAcrossShards = Integer.parseInt(argsLine.getOptionValue("total-warehouses"));
-    } else {
-      totalWarehousesAcrossShards = numWarehouses;
-    }
-
-    int loaderThreads = min(10,numWarehouses);
-    if (argsLine.hasOption("loaderthreads")) {
-      loaderThreads = Integer.parseInt(argsLine.getOptionValue("loaderthreads"));
-    }
+    int loaderThreads = options.getLoaderThreads().orElse(min(10, numWarehouses));
 
     // -------------------------------------------------------------------
     // GET PLUGIN LIST
@@ -233,12 +131,8 @@ public class DBWorkload {
     // Use this list for filtering of the output
     List<TransactionType> activeTXTypes = new ArrayList<>();
 
-    String configFile = "config/workload_all.xml";
-    if (argsLine.hasOption("c")) {
-      configFile = argsLine.getOptionValue("c");
-    }
-    XMLConfiguration xmlConfig = new XMLConfiguration(configFile);
-    xmlConfig.setExpressionEngine(new XPathExpressionEngine());
+    String configFile = options.getConfigFile().orElse("config/workload_all.xml");
+    ConfigFileOptions configOptions = new ConfigFileOptions(configFile);
 
     // Load the configuration for each benchmark
     int lastTxnId = 0;
@@ -252,90 +146,51 @@ public class DBWorkload {
       WorkloadConfiguration wrkld = new WorkloadConfiguration();
       wrkld.setBenchmarkName(plugin);
       boolean scriptRun = false;
-      if (argsLine.hasOption("t")) {
-        scriptRun = true;
-        String traceFile = argsLine.getOptionValue("t");
-        wrkld.setTraceReader(new TraceReader(traceFile));
-        if (LOG.isDebugEnabled()) LOG.debug(wrkld.getTraceReader().toString());
-      }
 
       // Pull in database configuration
-      wrkld.setDBDriver(xmlConfig.getString("driver"));
+      wrkld.setDBDriver(configOptions.getDbDriver());
 
       wrkld.setNodes(nodes);
 
-      wrkld.setDBName(xmlConfig.getString("DBName"));
-      wrkld.setDBUsername(xmlConfig.getString("username"));
-      wrkld.setDBPassword(xmlConfig.getString("password"));
+      wrkld.setDBName(configOptions.getDbName());
+      wrkld.setDBUsername(configOptions.getDbUsername());
+      wrkld.setDBPassword(configOptions.getDbPassword());
 
-      if (xmlConfig.containsKey("sslCert") && xmlConfig.getString("sslCert").length() > 0) {
-        wrkld.setSslCert(xmlConfig.getString("sslCert"));
-      }
-      if (xmlConfig.containsKey("sslKey") && xmlConfig.getString("sslKey").length() > 0) {
-        wrkld.setSslKey(xmlConfig.getString("sslKey"));
-      }
+      configOptions.getSslCert().ifPresent(wrkld::setSslCert);
+      configOptions.getSslKey().ifPresent(wrkld::setSslKey);
+      configOptions.getJdbcUrl().ifPresent(wrkld::setJdbcURL);
 
-      if (xmlConfig.containsKey("jdbcURL") && xmlConfig.getString("jdbcURL").length() > 0) {
-        wrkld.setJdbcURL(xmlConfig.getString("jdbcURL"));
-      }
-
-      int terminals = xmlConfig.getInt("terminals[not(@bench)]", numWarehouses * 10);
-      terminals = xmlConfig.getInt("terminals" + pluginTest, terminals);
+      int terminals = numWarehouses * 10;
       wrkld.setTerminals(terminals);
 
       wrkld.setLoaderThreads(loaderThreads);
 
-      String isolationMode = xmlConfig.getString("isolation[not(@bench)]", "TRANSACTION_SERIALIZABLE");
-      wrkld.setIsolationMode(xmlConfig.getString("isolation" + pluginTest, isolationMode));
+      wrkld.setIsolationMode(configOptions.getIsolationLevel().orElse("TRANSACTION_SERIALIZABLE"));
 
       wrkld.setNumWarehouses(numWarehouses);
       wrkld.setStartWarehouseIdForShard(startWarehouseIdForShard);
       wrkld.setTotalWarehousesAcrossShards(totalWarehousesAcrossShards);
 
-      if (xmlConfig.containsKey("useKeyingTime")) {
-        wrkld.setUseKeyingTime(xmlConfig.getBoolean("useKeyingTime"));
-      }
-      if (xmlConfig.containsKey("useThinkTime")) {
-        wrkld.setUseKeyingTime(xmlConfig.getBoolean("useThinkTime"));
-      }
+      configOptions.getUseKeyingTime().ifPresent(wrkld::setUseKeyingTime);
+      configOptions.getUseThinkTime().ifPresent(wrkld::setUseThinkTime);
+      configOptions.getEnableForeignKeysAfterLoad().ifPresent(wrkld::setEnableForeignKeysAfterLoad);
 
-      if (xmlConfig.containsKey("enableForeignKeysAfterLoad")) {
-        wrkld.setEnableForeignKeysAfterLoad(xmlConfig.getBoolean("enableForeignKeysAfterLoad"));
-      }
-      if (argsLine.hasOption("start-warehouse-id")) {
+      if (options.getStartWarehouseId().isPresent()) {
           wrkld.setShouldEnableForeignKeys(false);
       }
 
-      if (xmlConfig.containsKey("batchSize")) {
-        wrkld.setBatchSize(xmlConfig.getInt("batchSize"));
-      }
+      configOptions.getBatchSize().ifPresent(wrkld::setBatchSize);
+      configOptions.getMaxRetriesPerTransaction().ifPresent(wrkld::setMaxRetriesPerTransaction);
+      configOptions.getMaxLoaderRetries().ifPresent(wrkld::setMaxLoaderRetries);
 
-      if (xmlConfig.containsKey("maxRetriesPerTransaction")) {
-        wrkld.setMaxRetriesPerTransaction(xmlConfig.getInt("maxRetriesPerTransaction"));
-      }
+      configOptions.getTrackPerSQLStmtLatencies().ifPresent(InstrumentedPreparedStatement::trackLatencyMetrics);
 
-      if (xmlConfig.containsKey("maxLoaderRetries")) {
-        wrkld.setMaxLoaderRetries(xmlConfig.getInt("maxLoaderRetries"));
-      }
+      configOptions.getPort().ifPresent(wrkld::setPort);
 
-      if (xmlConfig.containsKey("trackPerSQLStmtLatencies")) {
-        InstrumentedPreparedStatement.trackLatencyMetrics(xmlConfig.getBoolean("trackPerSQLStmtLatencies"));
-      }
+      int numDBConnections = options.getNumDbConnections().orElse(min(numWarehouses, wrkld.getNodes().size() * 200));
+      wrkld.setNumDBConnections(numDBConnections);
 
-      if (xmlConfig.containsKey("port")) {
-        wrkld.setPort(xmlConfig.getInt("port"));
-      }
-
-      if (argsLine.hasOption("num-connections")) {
-         wrkld.setNumDBConnections(Integer.parseInt(argsLine.getOptionValue("num-connections")));
-      } else {
-        // We use a max of 200 connections per node so as to not overwhelm the DB cluster.
-        wrkld.setNumDBConnections(min(numWarehouses, wrkld.getNodes().size() * 200));
-      }
-
-      if (xmlConfig.containsKey("hikariConnectionTimeoutMs")) {
-        wrkld.setHikariConnectionTimeout(xmlConfig.getInt("hikariConnectionTimeoutMs"));
-      }
+      configOptions.getHikariConnectionTimeoutMs().ifPresent(wrkld::setHikariConnectionTimeout);
 
       if (wrkld.getNumDBConnections() <= 0) {
         wrkld.setNumDBConnections(wrkld.getTerminals());
@@ -345,25 +200,20 @@ public class DBWorkload {
         wrkld.setNumDBConnections(wrkld.getLoaderThreads());
       }
 
-      if (isBooleanOptionSet(argsLine, "execute") || isBooleanOptionSet(argsLine, "test") ||
-          isBooleanOptionSet(argsLine, "clear")) {
+      if (Arrays.asList(CommandLineOptions.Mode.CLEAR, CommandLineOptions.Mode.EXECUTE).contains(options.getMode())) {
         wrkld.setNeedsExecution(true);
       }
 
-      if (xmlConfig.containsKey("useStoredProcedures")) {
-        wrkld.setUseStoredProcedures(xmlConfig.getBoolean("useStoredProcedures"));
-      }
+      configOptions.getUseStoredProcedures().ifPresent(wrkld::setUseStoredProcedures);
 
-      if (!argsLine.hasOption("merge-results")) {
-        LOG.info("Configuration -> nodes: " + wrkld.getNodes() +
-                 ", port: " + wrkld.getPort() +
-                 ", startWH: " + wrkld.getStartWarehouseIdForShard() +
-                 ", warehouses: " + wrkld.getNumWarehouses() +
-                 ", total warehouses across shards: " + wrkld.getTotalWarehousesAcrossShards() +
-                 ", terminals: " + wrkld.getTerminals() +
-                 ", dbConnections: " + wrkld.getNumDBConnections() +
-                 ", loaderThreads: " + wrkld.getLoaderThreads() );
-      }
+      LOG.info("Configuration -> nodes: " + wrkld.getNodes() +
+               ", port: " + wrkld.getPort() +
+               ", startWH: " + wrkld.getStartWarehouseIdForShard() +
+               ", warehouses: " + wrkld.getNumWarehouses() +
+               ", total warehouses across shards: " + wrkld.getTotalWarehousesAcrossShards() +
+               ", terminals: " + wrkld.getTerminals() +
+               ", dbConnections: " + wrkld.getNumDBConnections() +
+               ", loaderThreads: " + wrkld.getLoaderThreads() );
 
       // ----------------------------------------------------------------
       // CREATE BENCHMARK MODULE
@@ -377,38 +227,30 @@ public class DBWorkload {
       initDebug.put("Isolation", wrkld.getIsolationString());
       initDebug.put("Scale Factor", wrkld.getNumWarehouses());
 
-      if (!argsLine.hasOption("merge-results")) {
-        LOG.info(SINGLE_LINE + "\n\n" + StringUtil.formatMaps(initDebug));
-        LOG.info(SINGLE_LINE);
-      }
+      LOG.info(SINGLE_LINE + "\n\n" + StringUtil.formatMaps(initDebug));
+      LOG.info(SINGLE_LINE);
 
       // ----------------------------------------------------------------
       // LOAD TRANSACTION DESCRIPTIONS
       // ----------------------------------------------------------------
-      int numTxnTypes = xmlConfig.configurationsAt("transactiontypes" + pluginTest + "/transactiontype").size();
-      if (numTxnTypes == 0 && targetList.length == 1) {
-        //if it is a single workload run, <transactiontypes /> w/o attribute is used
-        pluginTest = "[not(@bench)]";
-        numTxnTypes = xmlConfig.configurationsAt("transactiontypes" + pluginTest + "/transactiontype").size();
-      }
+      int numTxnTypes = configOptions.getTransactionTypeCount();
       wrkld.setNumTxnTypes(numTxnTypes);
 
       List<TransactionType> ttypes = new ArrayList<>();
       ttypes.add(TransactionType.INVALID);
+      List<String> weight_strings = new ArrayList<>();
       int txnIdOffset = lastTxnId;
       for (int i = 1; i <= wrkld.getNumTxnTypes(); i++) {
-        String key = "transactiontypes" + pluginTest + "/transactiontype[" + i + "]";
-        String txnName = xmlConfig.getString(key + "/name");
+        String txnName = configOptions.getTransactionTypeName(i)
+            .orElseThrow(() -> new RuntimeException("Every <transaction> in config must have a <name>."));
 
-        // Get ID if specified; else increment from last one.
-        int txnId = i;
-        if (xmlConfig.containsKey(key + "/id")) {
-          txnId = xmlConfig.getInt(key + "/id");
-        }
+        String weight = configOptions.getTransactionTypeWeight(i)
+            .orElseThrow(() -> new RuntimeException("Every <transaction> in config must have a <weight>."));
+        weight_strings.add(weight);
 
-        TransactionType tmpType = bench.initTransactionType(txnName, txnId + txnIdOffset);
+        TransactionType tmpType = bench.initTransactionType(txnName, i + txnIdOffset);
         if (txnName.equals("NewOrder")) {
-          newOrderTxnId = txnId + txnIdOffset;
+          newOrderTxnId = i + txnIdOffset;
         }
 
         // Keep a reference for filtering
@@ -424,180 +266,33 @@ public class DBWorkload {
       wrkld.setTransTypes(tt);
       LOG.debug("Using the following transaction types: " + tt);
 
-      // Read in the groupings of transactions (if any) defined for this
-      // benchmark
-      HashMap<String,List<String>> groupings = new HashMap<>();
-      int numGroupings = xmlConfig.configurationsAt("transactiontypes" + pluginTest + "/groupings/grouping").size();
-      LOG.debug("Num groupings: " + numGroupings);
-      for (int i = 1; i < numGroupings + 1; i++) {
-        String key = "transactiontypes" + pluginTest + "/groupings/grouping[" + i + "]";
-
-        // Get the name for the grouping and make sure it's valid.
-        String groupingName = xmlConfig.getString(key + "/name").toLowerCase();
-        if (!groupingName.matches("^[a-z]\\w*$")) {
-          LOG.fatal(String.format("Grouping name \"%s\" is invalid."
-                    + " Must begin with a letter and contain only"
-                    + " alphanumeric characters.", groupingName));
-          System.exit(-1);
-        }
-        else if (groupingName.equals("all")) {
-          LOG.fatal("Grouping name \"all\" is reserved."
-                    + " Please pick a different name.");
-          System.exit(-1);
-        }
-
-        // Get the weights for this grouping and make sure that there
-        // is an appropriate number of them.
-        List<String> groupingWeights = xmlConfig.getList(key + "/weights");
-        if (groupingWeights.size() != numTxnTypes) {
-          LOG.fatal(String.format("Grouping \"%s\" has %d weights, but there are %d transactions " +
-                                  "in this benchmark.", groupingName,
-                                  groupingWeights.size(), numTxnTypes));
-          System.exit(-1);
-        }
-
-        LOG.debug("Creating grouping with name, weights: " + groupingName + ", " + groupingWeights);
-        groupings.put(groupingName, groupingWeights);
-      }
-
-      // All benchmarks should also have an "all" grouping that gives
-      // even weight to all transactions in the benchmark.
-      List<String> weightAll = new ArrayList<>();
-      for (int i = 0; i < numTxnTypes; ++i)
-          weightAll.add("1");
-      groupings.put("all", weightAll);
       benchList.add(bench);
 
-      // ----------------------------------------------------------------
-      // WORKLOAD CONFIGURATION
-      // ----------------------------------------------------------------
+      int rate = configOptions.getRate()
+          .orElseThrow(() ->new RuntimeException("Must specify configuration value for rate."));
 
-      int size = xmlConfig.configurationsAt("/works/work").size();
-      for (int i = 1; i < size + 1; i++) {
-        SubnodeConfiguration work = xmlConfig.configurationAt("works/work[" + i + "]");
-        List<String> weight_strings;
+      time = configOptions.getRuntime()
+          .orElseThrow(() ->new RuntimeException("Must specify configuration value for runtime."));
 
-        // use a workaround if there multiple workloads or single
-        // attributed workload
-        if (targetList.length > 1 || work.containsKey("weights[@bench]")) {
-          String weightKey = work.getString("weights" + pluginTest).toLowerCase();
-          if (groupings.containsKey(weightKey))
-              weight_strings = groupings.get(weightKey);
-          else
-          weight_strings = getWeights(plugin, work);
-        } else {
-          String weightKey = work.getString("weights[not(@bench)]").toLowerCase();
-          if (groupings.containsKey(weightKey))
-              weight_strings = groupings.get(weightKey);
-          else
-          weight_strings = work.getList("weights[not(@bench)]");
-        }
-        int rate = 1;
-        boolean rateLimited = true;
-        boolean disabled = false;
+      warmupTime = options.getWarmupTime().orElse(warmupTime);
 
-        // can be "disabled", "unlimited" or a number
-        String rate_string;
-        rate_string = work.getString("rate[not(@bench)]", "");
-        rate_string = work.getString("rate" + pluginTest, rate_string);
-        if (rate_string.equals(RATE_DISABLED)) {
-          disabled = true;
-        } else if (rate_string.equals(RATE_UNLIMITED)) {
-          rateLimited = false;
-        } else if (rate_string.isEmpty()) {
-          LOG.fatal(String.format("Please specify the rate for phase %d and workload %s",
-                                  i, plugin));
-          System.exit(-1);
-        } else {
-          try {
-            rate = Integer.parseInt(rate_string);
-            if (rate < 1) {
-              LOG.fatal("Rate limit must be at least 1. Use unlimited or disabled values instead.");
-              System.exit(-1);
-            }
-          } catch (NumberFormatException e) {
-            LOG.fatal(String.format("Rate string must be '%s', '%s' or a number",
-                                    RATE_DISABLED, RATE_UNLIMITED));
-            System.exit(-1);
-          }
-        }
-        Phase.Arrival arrival=Phase.Arrival.REGULAR;
-        String arrive=work.getString("@arrival","regular");
-        if(arrive.equalsIgnoreCase("POISSON"))
-          arrival=Phase.Arrival.POISSON;
+      boolean timed = (time > 0);
+      if (warmupTime < 0) {
+        LOG.fatal("Must provide nonnegative time bound for"
+                + " warmup.");
+        System.exit(-1);
+      }
 
-        // If serial is enabled then run all queries exactly once in serial (rather than
-        // random) order
-        String serial_string;
-        serial_string = work.getString("serial[not(@bench)]", "false");
-        serial_string = work.getString("serial" + pluginTest, serial_string);
-        if (!Arrays.asList("true", "false").contains(serial_string)){
-          LOG.fatal(String.format(
-                  "Invalid string for serial: '%s'. Serial string must be 'true' or 'false'",
-                  serial_string));
-          System.exit(-1);
-        }
-        // We're not actually serial if we're running a script, so make
-        // sure to suppress the serial flag in this case.
-        boolean serial = serial_string.equals("true") && (wrkld.getTraceReader() == null);
-
-        int activeTerminals;
-        activeTerminals = work.getInt("active_terminals[not(@bench)]", terminals);
-        activeTerminals = work.getInt("active_terminals" + pluginTest, activeTerminals);
-        if (activeTerminals > terminals) {
-          LOG.error(String.format("Configuration error in work %d: "
-                + "Number of active terminals is bigger than the total number of terminals", i));
-          System.exit(-1);
-        }
-
-        time = work.getInt("/time", 0);
-
-        if (argsLine.hasOption("warmup-time-secs")) {
-          warmupTime = Integer.parseInt(argsLine.getOptionValue("warmup-time-secs"));
-        }
-
-        boolean timed = (time > 0);
-        if (scriptRun) {
-          LOG.info("Running a script; ignoring timer, serial, and weight settings.");
-        }
-        else if (!timed) {
-          if (serial) {
-            if (activeTerminals > 1) {
-              // For serial executions, we usually want only one terminal, but not always!
-              // (e.g. the CHBenCHmark)
-              LOG.warn("\n" + StringBoxUtil.heavyBox(String.format(
-                      "WARNING: Serial execution is enabled but the number of active terminals[=%d] > 1.\nIs this intentional??",
-                      activeTerminals)));
-            }
-            LOG.info("Timer disabled for serial run; will execute"
-                     + " all queries exactly once.");
-          } else {
-            LOG.fatal("Must provide positive time bound for"
-                      + " non-serial executions. Either provide"
-                      + " a valid time or enable serial mode.");
-            System.exit(-1);
-          }
-        }
-        else if (serial)
-          LOG.info("Timer enabled for serial run; will run queries"
-                   + " serially in a loop until the timer expires.");
-        if (warmupTime < 0) {
-          LOG.fatal("Must provide nonnegative time bound for"
-                  + " warmup.");
-          System.exit(-1);
-        }
-
-        wrkld.addWork(time,
-                      warmupTime,
-                      rate,
-                      weight_strings,
-                      rateLimited,
-                      disabled,
-                      serial,
-                      timed,
-                      activeTerminals,
-                      arrival);
-      } // FOR
+      wrkld.addWork(time,
+                    warmupTime,
+                    rate,
+                    weight_strings,
+                    true, // TODO -- remove all hard-coded parameters here
+                    false,
+                    false,
+                    timed,
+                    terminals,
+                    Phase.Arrival.REGULAR);
 
       // CHECKING INPUT PHASES
       int j = 0;
@@ -621,16 +316,17 @@ public class DBWorkload {
     assert(!benchList.isEmpty());
     assert(benchList.get(0) != null);
 
-    // Note to self and reviewer -- this was working before, but wasn't super useful..
-
-    if (argsLine.hasOption("initial-delay-secs")) {
-      int initialDelay = Integer.parseInt(argsLine.getOptionValue("initial-delay-secs"));
+    options.getInitialDelaySeconds().ifPresent((initialDelay) -> {
       LOG.info("Delaying execution of workload for " + initialDelay + " seconds");
-      Thread.sleep(initialDelay * 1000L);
-    }
+      try {
+        Thread.sleep(initialDelay * 1000L);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+    });
 
     // Create the Benchmark's Database
-    if (isBooleanOptionSet(argsLine, "create")) {
+    if (options.getMode() == CommandLineOptions.Mode.CREATE) {
       for (BenchmarkModule benchmark : benchList) {
         LOG.info("Creating new " + benchmark.getBenchmarkName().toUpperCase() + " database...");
         runCreator(benchmark);
@@ -644,7 +340,7 @@ public class DBWorkload {
     }
 
     // Clear the Benchmark's Database
-    if (isBooleanOptionSet(argsLine, "clear")) {
+    if (options.getMode() == CommandLineOptions.Mode.CLEAR) {
       for (BenchmarkModule benchmark : benchList) {
         LOG.info("Resetting " + benchmark.getBenchmarkName().toUpperCase() + " database...");
         benchmark.clearDatabase();
@@ -657,7 +353,7 @@ public class DBWorkload {
     }
 
     // Execute Loader
-    if (isBooleanOptionSet(argsLine, "load")) {
+    if (options.getMode() == CommandLineOptions.Mode.LOAD) {
       for (BenchmarkModule benchmark : benchList) {
         LOG.info(String.format("Loading data into %s database with %d threads...",
                                benchmark.getBenchmarkName().toUpperCase(),
@@ -671,62 +367,38 @@ public class DBWorkload {
       LOG.info(SINGLE_LINE);
     }
 
-    if (isBooleanOptionSet(argsLine, "enable-foreign-keys")) {
+    if (options.getIsEnableForeignKeysSet()) {
       for (BenchmarkModule benchmark : benchList) {
         benchmark.enableForeignKeys();
       }
     }
 
-    if (isBooleanOptionSet(argsLine, "create-sql-procedures")) {
+    if (options.getIsCreateSqlProceduresSet()) {
       for (BenchmarkModule benchmark : benchList) {
         benchmark.createSqlProcedures();
       }
     }
 
-    // Execute a Script
-    if (argsLine.hasOption("runscript")) {
-      for (BenchmarkModule benchmark : benchList) {
-        String script = argsLine.getOptionValue("runscript");
-        LOG.info("Running a SQL script: "+script);
-        runScript(benchmark, script);
-        LOG.info("Finished!");
-        LOG.info(SINGLE_LINE);
-      }
-    }
-
-    if (isBooleanOptionSet(argsLine, "test")) {
-        for (BenchmarkModule benchmark : benchList) {
-            benchmark.test();
-        }
-    }
-
     // Execute Workload
-    if (isBooleanOptionSet(argsLine, "execute")) {
+    if (options.getMode() == CommandLineOptions.Mode.EXECUTE) {
       // Bombs away!
       Results r = null;
       try {
-        r = runWorkload(benchList, intervalMonitor, xmlConfig);
+        r = runWorkload(benchList, intervalMonitor);
       } catch (Throwable ex) {
         LOG.error("Unexpected error when running benchmarks.", ex);
         System.exit(1);
       }
 
       // WRITE OUTPUT
-      writeOutputs(r, activeTXTypes, argsLine);
+      writeRawOutput(r, activeTXTypes);
 
       // WRITE HISTOGRAMS
-      if (argsLine.hasOption("histograms")) {
+      if (options.getIsOutputMetricHistogramsSet()) {
         writeHistograms(r);
       }
     } else {
       LOG.info("Skipping benchmark workload execution");
-    }
-
-    if (isBooleanOptionSet(argsLine, "merge-results")) {
-      String dirPath = argsLine.getOptionValue("dir");
-      File dir = new File(dirPath);
-      String[] files = dir.list();
-      mergeResults(dirPath, files);
     }
   }
 
@@ -767,95 +439,16 @@ public class DBWorkload {
   /**
    * Write out the results for a benchmark run to a bunch of files.
    */
-  private static void writeOutputs(Results r, List<TransactionType> activeTXTypes, CommandLine argsLine)
-                                   throws Exception {
-    // If an output directory is used, store the information
+  private static void writeRawOutput(Results r, List<TransactionType> activeTXTypes) throws FileNotFoundException {
     String outputDirectory = "results";
-    if (argsLine.hasOption("d")) {
-      outputDirectory = argsLine.getOptionValue("d");
-    }
-    String filePrefix = "";
-    if (argsLine.hasOption("t")) {
-      filePrefix = new Timestamp(System.currentTimeMillis()) + "_";
-    }
+    FileUtil.makeDirIfNotExists(outputDirectory.split("/"));
+    String baseFile = "oltpbench";
 
-    // Output target
-    PrintStream ps = null;
-    PrintStream rs = null;
-    String baseFileName = "oltpbench";
-    if (argsLine.hasOption("o")) {
-      if (argsLine.getOptionValue("o").equals("-")) {
-        ps = System.out;
-        rs = System.out;
-        baseFileName = null;
-      } else {
-        baseFileName = argsLine.getOptionValue("o");
-      }
-    }
-
-    // Build the complex path
-    String baseFile = filePrefix;
-    String nextName;
-
-    if (baseFileName != null) {
-      // Check if directory needs to be created
-      if (outputDirectory.length() > 0) {
-        FileUtil.makeDirIfNotExists(outputDirectory.split("/"));
-      }
-
-      baseFile = filePrefix + baseFileName;
-
-      if (argsLine.getOptionValue("output-raw", "true").equalsIgnoreCase("true")) {
-        // RAW OUTPUT
-        nextName = FileUtil.getNextFilename(outputDirectory, baseFile, ".csv");
-        rs = new PrintStream(nextName);
-        LOG.info("Output Raw data into file: " + nextName);
-        r.writeAllCSVAbsoluteTiming(activeTXTypes, rs);
-        rs.close();
-      }
-
-      if (isBooleanOptionSet(argsLine, "output-samples")) {
-        // Write samples using 1 second window
-        nextName = FileUtil.getNextFilename(outputDirectory, baseFile, ".samples");
-        rs = new PrintStream(nextName);
-        LOG.info("Output samples into file: " + nextName);
-        r.writeCSV2(rs);
-        rs.close();
-      }
-    } else if (LOG.isDebugEnabled()) {
-      LOG.debug("No output file specified");
-    }
-
-    // SUMMARY FILE
-    if (argsLine.hasOption("s")) {
-      nextName = FileUtil.getNextFilename(outputDirectory, baseFile, ".res");
-      ps = new PrintStream(nextName);
-      LOG.info("Output throughput samples into file: " + nextName);
-
-      int windowSize = Integer.parseInt(argsLine.getOptionValue("s"));
-      LOG.info("Grouped into Buckets of " + windowSize + " seconds");
-      r.writeCSV(windowSize, ps);
-
-      // Allow more detailed reporting by transaction to make it easier to check
-      if (argsLine.hasOption("ss")) {
-        for (TransactionType t : activeTXTypes) {
-          PrintStream ts = ps;
-          if (ts != System.out) {
-            // Get the actual filename for the output
-            baseFile = filePrefix + baseFileName + "_" + t.getName();
-            nextName = FileUtil.getNextFilename(outputDirectory, baseFile, ".res");
-            ts = new PrintStream(nextName);
-            r.writeCSV(windowSize, ts, t);
-            ts.close();
-          }
-        }
-      }
-    } else if (LOG.isDebugEnabled()) {
-      LOG.warn("No bucket size specified");
-    }
-
-    if (ps != null) ps.close();
-    if (rs != null) rs.close();
+    String nextName = FileUtil.getNextFilename(outputDirectory, baseFile, ".csv");
+    PrintStream rs = new PrintStream(nextName);
+    LOG.info("Output Raw data into file: " + nextName);
+    r.writeAllCSVAbsoluteTiming(activeTXTypes, rs);
+    rs.close();
   }
 
   /* buggy piece of shit of Java XPath implementation made me do it
@@ -886,11 +479,6 @@ public class DBWorkload {
     return weight_strings;
   }
 
-  private static void runScript(BenchmarkModule bench, String script) {
-    LOG.debug(String.format("Running %s", script));
-    bench.runScript(script);
-  }
-
   private static void runCreator(BenchmarkModule bench) {
     LOG.debug(String.format("Creating %s Database", bench));
     bench.createDatabase();
@@ -901,9 +489,7 @@ public class DBWorkload {
     bench.loadDatabase();
   }
 
-  private static Results runWorkload(List<BenchmarkModule> benchList,
-                                     int intervalMonitor,
-                                     XMLConfiguration xmlConfig) {
+  private static Results runWorkload(List<BenchmarkModule> benchList, int intervalMonitor) {
     List<Worker> workers = new ArrayList<>();
     List<WorkloadConfiguration> workConfs = new ArrayList<>();
 
@@ -1145,24 +731,7 @@ public class DBWorkload {
     }
   }
 
-  private static void printUsage(Options options) {
-    HelpFormatter hlpfrmt = new HelpFormatter();
-    hlpfrmt.printHelp("tpccbenchmark", options);
-  }
 
-  /**
-   * Returns true if the given key is in the CommandLine object and is set to
-   * true.
-   */
-  private static boolean isBooleanOptionSet(CommandLine argsLine, String key) {
-    if (argsLine.hasOption(key)) {
-      LOG.debug("CommandLine has option '" + key + "'. Checking whether set to true");
-      String val = argsLine.getOptionValue(key);
-      LOG.debug(String.format("CommandLine %s => %s", key, val));
-      return val != null && val.equalsIgnoreCase("true");
-    }
-    return (false);
-  }
 
   public static String getAssertWarning() {
     String msg = "!!! WARNING !!!\n" +

--- a/src/com/oltpbenchmark/api/Procedure.java
+++ b/src/com/oltpbenchmark/api/Procedure.java
@@ -19,7 +19,6 @@ package com.oltpbenchmark.api;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -28,7 +27,6 @@ import java.util.Map.Entry;
 import java.util.Random;
 
 import com.oltpbenchmark.jdbc.InstrumentedPreparedStatement;
-import org.HdrHistogram.Histogram;
 import org.apache.log4j.Logger;
 
 public abstract class Procedure {
@@ -65,36 +63,12 @@ public abstract class Procedure {
      * for the target DBMS is used for this SQLStmt.
      * This will automatically call setObject for all the parameters you pass in.
      */
-    public final PreparedStatement getPreparedStatement(Connection conn, SQLStmt stmt, Object...params) throws SQLException {
-        PreparedStatement pStmt = this.getPreparedStatementReturnKeys(conn, stmt);
-        for (int i = 0; i < params.length; i++) {
-            pStmt.setObject(i+1, params[i]);
-        } // FOR
-        return (pStmt);
-    }
-
     public final InstrumentedPreparedStatement getPreparedStatement(Connection conn,
-                                                                    InstrumentedSQLStmt stmt,
-                                                                    Object...params) throws SQLException {
-        PreparedStatement pStmt = this.getPreparedStatement(conn, stmt.getSqlStmt(), params);
-        return new InstrumentedPreparedStatement(pStmt, stmt);
-    }
-
-
-    /**
-     * Return a PreparedStatement for the given SQLStmt handle
-     * The underlying Procedure API will make sure that the proper SQL
-     * for the target DBMS is used for this SQLStmt.
-     */
-    public final PreparedStatement getPreparedStatementReturnKeys(Connection conn, SQLStmt stmt) throws SQLException {
+                                                                    InstrumentedSQLStmt stmt) throws SQLException {
         assert(this.name_stmt_xref != null) : "The Procedure " + this + " has not been initialized yet!";
-        PreparedStatement pStmt;
         assert(this.stmt_name_xref.containsKey(stmt)) :
-            "Unexpected SQLStmt handle in " + this.getClass().getSimpleName() + "\n" + this.name_stmt_xref;
-
-        pStmt = conn.prepareStatement(stmt.getSQL());
-        assert(pStmt != null) : "Unexpected null PreparedStatement for " + stmt;
-        return (pStmt);
+                "Unexpected SQLStmt handle in " + this.getClass().getSimpleName() + "\n" + this.name_stmt_xref;
+        return new InstrumentedPreparedStatement(conn.prepareStatement(stmt.getSqlStmt().getSQL()), stmt);
     }
     
     protected static Map<String, SQLStmt> getStatments(Procedure proc) {


### PR DESCRIPTION
Was getting hard to track how various options effected execution, so pulling reading of options into separate files should hopefully clarify semantics of various knobs going forward.

Also removes a bunch of unused knobs