### PR TITLE
Hikari pool connection fixes.

### DIFF
--- a/src/com/oltpbenchmark/DBWorkload.java
+++ b/src/com/oltpbenchmark/DBWorkload.java
@@ -203,6 +203,15 @@ public class DBWorkload {
                ", dbConnections: " + wrkld.getNumDBConnections() +
                ", loaderThreads: " + wrkld.getLoaderThreads() );
 
+      options.getInitialDelaySeconds().ifPresent((initialDelay) -> {
+        LOG.info("Delaying execution of workload for " + initialDelay + " seconds");
+        try {
+          Thread.sleep(initialDelay * 1000L);
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+      });
+
       // ----------------------------------------------------------------
       // CREATE BENCHMARK MODULE
       // ----------------------------------------------------------------
@@ -303,15 +312,6 @@ public class DBWorkload {
     }
     assert(!benchList.isEmpty());
     assert(benchList.get(0) != null);
-
-    options.getInitialDelaySeconds().ifPresent((initialDelay) -> {
-      LOG.info("Delaying execution of workload for " + initialDelay + " seconds");
-      try {
-        Thread.sleep(initialDelay * 1000L);
-      } catch (InterruptedException e) {
-        e.printStackTrace();
-      }
-    });
 
     // Create the Benchmark's Database
     if (options.getMode() == CommandLineOptions.Mode.CREATE) {

--- a/src/com/oltpbenchmark/api/BenchmarkModule.java
+++ b/src/com/oltpbenchmark/api/BenchmarkModule.java
@@ -97,6 +97,7 @@ public class BenchmarkModule {
             props.setProperty("dataSource.databaseName", workConf.getDBName());
             props.setProperty("maximumPoolSize", Integer.toString(numConnections));
             props.setProperty("connectionTimeout", Integer.toString(workConf.getHikariConnectionTimeout()));
+            props.setProperty("maxLifetime", "0");
             props.setProperty("dataSource.reWriteBatchedInserts", "true");
             if (workConf.getSslCert() != null && workConf.getSslCert().length() > 0) {
               assert(workConf.getSslKey().length() > 0) : "The SSL key is empty.";


### PR DESCRIPTION
1. Set the maxLifetime of the connection so as to not close the
   connection after 30 minutes.
2. Make sure the sleep due to initial-delay-secs happens before the
   constructor of the BenchmarkModule so as to sleep before the creation
   of the HikariPool.

Reviewers:
Mihnea