### PR TITLE
Remove FOR UPDATE from NewOrder transaction.

### DIFF
--- a/src/com/oltpbenchmark/benchmarks/tpcc/procedures/NewOrder.java
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/procedures/NewOrder.java
@@ -182,7 +182,7 @@ public class NewOrder extends Procedure {
       } else {
         sb.append(",?");
       }
-      stmtGetStockSQLArr[i - 1] = new InstrumentedSQLStmt(stmtGetStockSQL.getHistogram(), sb.toString() + ") FOR UPDATE");
+      stmtGetStockSQLArr[i - 1] = new InstrumentedSQLStmt(stmtGetStockSQL.getHistogram(), sb.toString() + ")");
     }
 
     // We create 15 statements to update the rows in `STOCK` table. Each string looks like:


### PR DESCRIPTION
The NewOrder transaction performs an Update on the Stock table for which
we are performing the Selects. Hence the 'FOR UPDATE' is unnecessary
here as we are using Repeatable Read isolation as the transactions will
conflict when we perform the Update.

Reviewers:
Mihnea, Rob