### PR TITLE
Block workers and master post warmup phase 

### DIFF
--- a/src/com/oltpbenchmark/ThreadBench.java
+++ b/src/com/oltpbenchmark/ThreadBench.java
@@ -453,7 +453,15 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
           }
           interruptWorkers();
         }
-        start = now;
+        if (testState.getState() == State.MEASURE && phase.warmupTime > 0) {
+            LOG.info(StringUtil.bold("POST WARMUP") + " :: Warmup time over, blocking for other threads.");
+            // Block for all threads to finish the warmup phase
+            testState.blockPostWarmup();
+            // Start the timer for measure phase after all threads complete the warmup phase
+            start = System.nanoTime();
+        } else{
+            start = now;
+        }
         LOG.info(StringUtil.bold("MEASURE") + " :: Warmup complete, starting measurements.");
         // measureEnd = measureStart + measureSeconds * 1000000000L;
 

--- a/src/com/oltpbenchmark/WorkloadState.java
+++ b/src/com/oltpbenchmark/WorkloadState.java
@@ -242,6 +242,10 @@ public class WorkloadState {
     }
   }
 
+  public void blockPostWarmup() {
+    benchmarkState.blockPostWarmup();
+  }
+
   /**
    * Delegates a global state query to the benchmark state handler
    *


### PR DESCRIPTION
.. so that the events of WARMUP phase finish before the MEASURE phase. Currently events of warmup phase continue to run during the MEASURE phase. These events are not accounted in stats but time is lost in running them causing efficiency loss during MEASURE phase.