### PR TITLE
Exception when number of records in LatencyRecord was a multiple of ALLOC_SIZE

### DIFF
--- a/src/com/oltpbenchmark/LatencyRecord.java
+++ b/src/com/oltpbenchmark/LatencyRecord.java
@@ -92,7 +92,10 @@ public class LatencyRecord implements Iterable<LatencyRecord.Sample> {
       if (chunkIndex < values.size() - 1) {
         return true;
       }
-
+      else if (chunkIndex > values.size() - 1) {
+        return false;
+      }
+      
       assert chunkIndex == values.size() - 1;
       if (subIndex < nextIndex) {
         return true;


### PR DESCRIPTION
Following exception was hit 
```
Exception in thread "main" java.lang.IndexOutOfBoundsException: Index: 2, Size: 2
	at java.util.ArrayList.rangeCheck(ArrayList.java:659)
	at java.util.ArrayList.get(ArrayList.java:435)
	at com.company.LatencyRecord$LatencyRecordIterator.next(LatencyRecord.java:109)
	at com.company.LatencyRecord$LatencyRecordIterator.next(LatencyRecord.java:84)
```
