### PR TITLE
Single connection option

### DIFF
--- a/src/com/oltpbenchmark/CommandLineOptions.java
+++ b/src/com/oltpbenchmark/CommandLineOptions.java
@@ -60,6 +60,7 @@ public class CommandLineOptions {
         COMMAND_LINE_OPTS.addOption(null, "merge-results", true, "Merge results from various output files");
         COMMAND_LINE_OPTS.addOption(null, "dir", true, "Directory containing the csv files");
         COMMAND_LINE_OPTS.addOption(null, "vv", false, "Output verbose execute results");
+        COMMAND_LINE_OPTS.addOption(null, "single-transaction", false, "Examine RPC requests of a single random transaction");
     }
 
     public CommandLineOptions() {}
@@ -173,4 +174,6 @@ public class CommandLineOptions {
     }
 
     public boolean getShouldOutputVerboseExecuteResults() { return argsLine.hasOption("vv"); }
+
+    public boolean getSingleTransactionRPC() { return argsLine.hasOption("single-transaction"); }
 }

--- a/src/com/oltpbenchmark/DBWorkload.java
+++ b/src/com/oltpbenchmark/DBWorkload.java
@@ -214,7 +214,7 @@ public class DBWorkload {
       // ----------------------------------------------------------------
       // CREATE BENCHMARK MODULE
       // ----------------------------------------------------------------
-      BenchmarkModule bench = new BenchmarkModule(wrkld);
+      BenchmarkModule bench = new BenchmarkModule(wrkld, options);
       Map<String, Object> initDebug = new ListOrderedMap<>();
       initDebug.put("Benchmark", String.format("%s {%s}", plugin.toUpperCase(), "BenchmarkModule"));
       initDebug.put("Configuration", configFile);


### PR DESCRIPTION
Add a new command-line option: --single-transaction to examine RPC requests of a single random transaction.

Usage:
`./tpccbenchmark --execute=true --single-transaction`