### PR TITLE
Remove dependency of non partitioned TPCC run on file config/geopartitioned_workload.xml

### DIFF
--- a/src/com/oltpbenchmark/CommandLineOptions.java
+++ b/src/com/oltpbenchmark/CommandLineOptions.java
@@ -44,7 +44,7 @@ public class CommandLineOptions {
                 "gpc",
                 "geopartitioned-config",
                 true,
-                "GeoPartitioning configuration file [default: config/geopartitioned_workload.xml]");
+                "GeoPartitioning configuration file");
 
         COMMAND_LINE_OPTS.addOption("im", "interval-monitor", true,
                 "Throughput Monitoring Interval in milliseconds");

--- a/src/com/oltpbenchmark/DBWorkload.java
+++ b/src/com/oltpbenchmark/DBWorkload.java
@@ -133,11 +133,14 @@ public class DBWorkload {
       // BEGIN LOADING WORKLOAD CONFIGURATION
       // ----------------------------------------------------------------
 
-      String geopartitionedConfigFile = options.getGeoPartitionedConfigFile().orElse("config/geopartitioned_workload.xml");
-      GeoPartitionedConfigFileOptions geopartitionedConfigOptions = new GeoPartitionedConfigFileOptions(geopartitionedConfigFile);
-      GeoPartitionPolicy geoPartitionPolicy = geopartitionedConfigOptions.getGeoPartitionPlacement(totalWarehousesAcrossShards, numWarehouses, startWarehouseIdForShard);
-      
+      String geopartitionedConfigFile = options.getGeoPartitionedConfigFile().orElse("");
+      GeoPartitionPolicy geoPartitionPolicy = null;
+      if (!geopartitionedConfigFile.isEmpty()) {
+          GeoPartitionedConfigFileOptions geopartitionedConfigOptions = new GeoPartitionedConfigFileOptions(geopartitionedConfigFile);
+          geoPartitionPolicy = geopartitionedConfigOptions.getGeoPartitionPlacement(totalWarehousesAcrossShards, numWarehouses, startWarehouseIdForShard);
+      }
       WorkloadConfiguration wrkld = new WorkloadConfiguration(geoPartitionPolicy);
+      
       wrkld.setBenchmarkName(plugin);
 
       // Pull in database configuration


### PR DESCRIPTION
TPCCBenchmark assumes the presence of the file
config/geopartitioned_workload.xml. If the benchmark
is run from a directory that does not have the above file,
it causes the benchmark to fail with FileNotFoundException.

Instead, if no file is specified as part of the command line
options, the benchmark should just assume that geopartitioning
is disabled.

This patch introduces changes for the above fix.
Tested by running TPCC --create for both nonpartitioned and
partitioned setups with and without the file present.