### PR TITLE
Fix for DemicalFormatException caused due to grouping in double number

### DIFF
--- a/src/com/oltpbenchmark/DBWorkload.java
+++ b/src/com/oltpbenchmark/DBWorkload.java
@@ -520,6 +520,7 @@ public class DBWorkload {
             String.format("%18s | %17.2f%%\n", "Efficiency", efficiency) +
             String.format("%18s | %18.2f\n", "Throughput (req/s)", r.getRequestsPerSecond());
     LOG.info(resultOut);
+    df.setGroupingUsed(false);
     jsonMetricsHelper.setTestResults(df.format(tpmc), df.format(efficiency),
             df.format(r.getRequestsPerSecond()));
   }


### PR DESCRIPTION
Fix for the exception : 
```
ERROR - Unexpected error when running benchmarks. 
java.lang.NumberFormatException: For input string: "1,288.4", 
      at sun.misc.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:2043)
      at sun.misc.FloatingDecimal.parseDouble(FloatingDecimal.java:110)
      at java.lang.Double.parseDouble(Double.java:538)
      at com.oltpbenchmark.benchmarks.tpcc.JsonMetricsHelper.setTestResults(JsonMetricsHelper.java:38)
      at com.oltpbenchmark.DBWorkload.PrintToplineResults(DBWorkload.java:523)
      at com.oltpbenchmark.DBWorkload.runWorkload(DBWorkload.java:482)
      at com.oltpbenchmark.DBWorkload.main(DBWorkload.java:384)
```