### PR TITLE
Multiple prepare statements issue during inserts

### DIFF
--- a/src/com/oltpbenchmark/api/Loader.java
+++ b/src/com/oltpbenchmark/api/Loader.java
@@ -185,12 +185,16 @@ public class Loader {
       SQLException failure = null;
       for (int i = 0; i < attempts; ++i) {
         try {
-           for (ArrayList<PreparedStatement> stmt: stmts) {
-             stmt.get(i).executeBatch();
-             stmt.get(i).clearBatch();
-           }
-           conn.commit();
-           return;
+          for (ArrayList<PreparedStatement> stmt : stmts) {
+            stmt.get(i).executeBatch();
+          }
+          conn.commit();
+          for (ArrayList<PreparedStatement> stmt : stmts) {
+            for (PreparedStatement preparedStatement : stmt) {
+              preparedStatement.clearBatch();
+            }
+          }
+          return;
         } catch (SQLException ex) {
           LOG.warn("Fail to load batch with error: " + ex.getMessage());
           failure = ex;

--- a/src/com/oltpbenchmark/api/Loader.java
+++ b/src/com/oltpbenchmark/api/Loader.java
@@ -182,10 +182,12 @@ public class Loader {
         try {
            for (PreparedStatement stmt: stmts) {
               stmt.executeBatch();
-              stmt.clearBatch();
            }
-            conn.commit();
-            return;
+           conn.commit();
+           for (PreparedStatement stmt: stmts) {
+             stmt.clearBatch();
+           }
+           failure = null;
         } catch (SQLException ex) {
           LOG.warn("Fail to load batch with error: " + ex.getMessage());
           failure = ex;

--- a/src/com/oltpbenchmark/api/Loader.java
+++ b/src/com/oltpbenchmark/api/Loader.java
@@ -165,6 +165,9 @@ public class Loader {
 
     private ArrayList<PreparedStatement> getInsertStatement(Connection conn, String tableName) throws SQLException {
       int attempts = workConf.getMaxLoaderRetries() + 1;
+      // Number prepared statements for every insert statement should be equal to number of retries.
+      // If there is an exception in insert, same prepared statement cannot be used to retry in certain cases.
+      // Exceptions are thrown. So for every retry we will use a different prepared statement.
       ArrayList<PreparedStatement> statements = new ArrayList<>();
       for (int i = 0; i < attempts; ++i) {
         statements.add(conn.prepareStatement(Table.getInsertDml(tableName)));
@@ -183,6 +186,11 @@ public class Loader {
     private void performInsertsWithRetries(Connection conn, ArrayList<PreparedStatement>... stmts) throws Exception {
       int attempts = workConf.getMaxLoaderRetries() + 1;
       SQLException failure = null;
+      // If there is an exception in insert, same prepared statement
+      // cannot be used to retry in certain cases. So for every retry we will use a
+      // different prepared statement. Clear all the prepared statement after one is successful.
+      // Not the best way to solve the problem but lot of re-organizing would be
+      // needed if we want a different approach
       for (int i = 0; i < attempts; ++i) {
         try {
           for (ArrayList<PreparedStatement> stmt : stmts) {


### PR DESCRIPTION
Number prepared statements for every insert statement should be equal to number of retries. If there is an exception in insert, same prepared statement cannot be used to retry in certain cases. So for every retry we will use a different prepared statement. Clear all the prepared statement after one is successful. 


Not the best way to solve the problem but lot of re-organizing would be needed if we want a different approach.
      