### PR TITLE
- revert FOR KEY SHARE changes, as it is affecting select query perforrmance.

### DIFF
--- a/src/com/oltpbenchmark/benchmarks/tpcc/procedures/NewOrder.java
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/procedures/NewOrder.java
@@ -49,7 +49,7 @@ public class NewOrder extends Procedure {
       "  FROM " + TPCCConstants.TABLENAME_CUSTOMER +
       " WHERE C_W_ID = ? " +
       "   AND C_D_ID = ? " +
-      "   AND C_ID = ? FOR KEY SHARE");
+      "   AND C_ID = ?");
 
   public static final InstrumentedSQLStmt stmtGetWhseSQL = new InstrumentedSQLStmt(
       "SELECT W_TAX " +
@@ -176,7 +176,7 @@ public class NewOrder extends Procedure {
       } else {
         sb.append(",?");
       }
-      stmtGetStockSQLArr[i - 1] = new InstrumentedSQLStmt(stmtGetStockSQL.getHistogram(), sb.toString() + ") FOR KEY SHARE");
+      stmtGetStockSQLArr[i - 1] = new InstrumentedSQLStmt(stmtGetStockSQL.getHistogram(), sb.toString() + ")");
     }
 
     // We create 15 statements to update the rows in `STOCK` table. Each string looks like:


### PR DESCRIPTION
There was performance degradation in the select queries after these changes were introduced. Hence reverting the changes.This issue is been tracked on github with ticket https://github.com/yugabyte/yugabyte-db/issues/13258