### PR TITLE
Remove call to getTransactionIsolation as it is not needed and is throwing an error

### DIFF
--- a/src/com/oltpbenchmark/api/Worker.java
+++ b/src/com/oltpbenchmark/api/Worker.java
@@ -487,13 +487,6 @@ public class Worker implements Runnable {
                 conn.setAutoCommit(false);
             }
 
-            if (LOG.isDebugEnabled() && conn.getTransactionIsolation() != wrkld.getIsolationMode()) {
-                throw new RuntimeException(String.format(
-                    "Unexpected connection isolation level. Expected (%s), got (%s).",
-                    wrkld.getIsolationMode(),
-                    conn.getTransactionIsolation()));
-            }
-
             endConnection = System.nanoTime();
             int attempt = 0;
 


### PR DESCRIPTION
There is a call for conn.getTransactionIsolation() from tpcc code. This code gets executed only when debug logging is enabled.  This call to conn.getTransactionIsolation() is throwing an exception and looks like a driver issue. This code is unimportant in tpcc and hence fixing the issue for now by removing the code.